### PR TITLE
fix: fixed Navigation Drawer appearing on Login Page

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -38,8 +38,8 @@ export class OrganizerAppComponent {
 
   public logout() {
     localStorage.removeItem(Config.ACCESS_TOKEN_NAME);
-    this.nav.setRoot(LoginPage);
     this.menuCtrl.close();
+    this.nav.setRoot(LoginPage);
   }
 
   private handleRoot() {

--- a/src/pages/events/events.ts
+++ b/src/pages/events/events.ts
@@ -1,6 +1,6 @@
 import {Component} from "@angular/core";
 import {Storage} from "@ionic/storage";
-import {NavController} from "ionic-angular";
+import {NavController, MenuController} from "ionic-angular";
 import {IEvent} from "../../interfaces/event";
 import {EventsService} from "../../services/events.service";
 import {EventDashboardPage} from "../event-dashboard/event-dashboard";
@@ -17,7 +17,12 @@ export class EventsPage {
   public isLoading: boolean = true;
   public pickedEvent: IEvent;
 
-  constructor(private navCtrl: NavController, private eventService: EventsService, private storage: Storage) {
+  constructor(private navCtrl: NavController,
+              private menuCtrl: MenuController,
+              private eventService: EventsService,
+              private storage: Storage) {
+    
+    this.menuCtrl.enable(true);
     this.isLoading = true;
 
     this.storage.get("event").then((event) => {

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -1,7 +1,7 @@
 import {Component} from "@angular/core";
 import {Storage} from "@ionic/storage";
 import {provideAuth} from "angular2-jwt";
-import {AlertController, NavController} from "ionic-angular";
+import {AlertController, NavController, MenuController} from "ionic-angular";
 import {Config} from "../../app/config";
 import {LoginService} from "../../services/login.service";
 import {UserService} from "../../services/user.service";
@@ -20,10 +20,13 @@ export class LoginPage {
   public isLoading: boolean;
 
   constructor(private navCtrl: NavController,
+              private menuCtrl: MenuController,
               private loginService: LoginService,
               public alertCtrl: AlertController,
               private userService: UserService,
               private storage: Storage) {
+
+    this.menuCtrl.enable(false);
 
     this.credentials = {
       email: null,
@@ -31,7 +34,7 @@ export class LoginPage {
     };
 
     this.isLoading = false;
-
+    
     if (Config.SERVER) {
       this.server = Config.SERVER;
     }


### PR DESCRIPTION
**Fixes #58**: Logout Navigation Drawer Page access removed from the Login Page

**Changes Done:**
- Disabled the MenuController on the Login Page by adding  `this.menuCtrl.enable(true);`
- Enabled the MenuController back when user logs in by  `this.menuCtrl.enable(true);`
- Changed the order of execution in logout method to fix an inconsistent state of Navigation Drawer. Functionality remains unaffected.