### PR TITLE
fix: Editor Config following Android specific guidelines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 # We recommend you to keep these unchanged
 end_of_line = lf


### PR DESCRIPTION
Fixes #86 

- Use 4 spaces instead of 2