### PR TITLE
feat: Share event parcel to display initial info

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/data/models/Event.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/models/Event.java
@@ -1,10 +1,13 @@
 package org.fossasia.openevent.app.data.models;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 
-public class Event {
+public class Event implements Parcelable {
 
     @SerializedName("background_image")
     private String backgroundImage;
@@ -366,15 +369,85 @@ public class Event {
     @Override
     public String toString() {
         return "Event{" +
-            "description='" + description + '\'' +
+            "backgroundImage='" + backgroundImage + '\'' +
+            ", description='" + description + '\'' +
             ", email='" + email + '\'' +
+            ", endTime='" + endTime + '\'' +
+            ", eventUrl='" + eventUrl + '\'' +
             ", id=" + id +
-            ", locationName='" + locationName + '\'' +
+            ", logo='" + logo + '\'' +
             ", name='" + name + '\'' +
-            ", organizerDescription='" + organizerDescription + '\'' +
             ", organizerName='" + organizerName + '\'' +
-            ", topic='" + topic + '\'' +
+            ", placeholderUrl='" + placeholderUrl + '\'' +
+            ", startTime='" + startTime + '\'' +
+            ", thumbnail='" + thumbnail + '\'' +
+            ", ticketUrl='" + ticketUrl + '\'' +
+            ", tickets=" + tickets +
+            ", timezone='" + timezone + '\'' +
+            ", type='" + type + '\'' +
             ", version=" + version +
             '}';
     }
+
+    // Parcelable Information - Only basic event info
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.backgroundImage);
+        dest.writeString(this.description);
+        dest.writeString(this.email);
+        dest.writeString(this.endTime);
+        dest.writeString(this.eventUrl);
+        dest.writeValue(this.id);
+        dest.writeString(this.large);
+        dest.writeString(this.locationName);
+        dest.writeString(this.logo);
+        dest.writeString(this.name);
+        dest.writeString(this.organizerName);
+        dest.writeString(this.placeholderUrl);
+        dest.writeString(this.startTime);
+        dest.writeString(this.thumbnail);
+        dest.writeString(this.ticketUrl);
+        dest.writeString(this.timezone);
+        dest.writeString(this.topic);
+        dest.writeString(this.type);
+    }
+
+    protected Event(Parcel in) {
+        this.backgroundImage = in.readString();
+        this.description = in.readString();
+        this.email = in.readString();
+        this.endTime = in.readString();
+        this.eventUrl = in.readString();
+        this.id = (Long) in.readValue(Long.class.getClassLoader());
+        this.large = in.readString();
+        this.locationName = in.readString();
+        this.logo = in.readString();
+        this.name = in.readString();
+        this.organizerName = in.readString();
+        this.placeholderUrl = in.readString();
+        this.startTime = in.readString();
+        this.thumbnail = in.readString();
+        this.ticketUrl = in.readString();
+        this.timezone = in.readString();
+        this.topic = in.readString();
+        this.type = in.readString();
+    }
+
+    public static final Parcelable.Creator<Event> CREATOR = new Parcelable.Creator<Event>() {
+        @Override
+        public Event createFromParcel(Parcel source) {
+            return new Event(source);
+        }
+
+        @Override
+        public Event[] newArray(int size) {
+            return new Event[size];
+        }
+    };
 }

--- a/app/src/main/java/org/fossasia/openevent/app/event/attendees/AttendeesActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/event/attendees/AttendeesActivity.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.Toast;
@@ -43,6 +42,8 @@ public class AttendeesActivity extends AppCompatActivity implements IAttendeesVi
 
     private IAttendeesPresenter attendeesPresenter;
 
+    // Lifecycle methods
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -70,6 +71,12 @@ public class AttendeesActivity extends AppCompatActivity implements IAttendeesVi
     }
 
     @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        attendeesPresenter.detach();
+    }
+
+    @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (data != null) {
             if (requestCode == REQ_CODE) {
@@ -83,6 +90,8 @@ public class AttendeesActivity extends AppCompatActivity implements IAttendeesVi
             super.onActivityResult(requestCode, resultCode, data);
         }
     }
+
+    // View implementation start
 
     @Override
     public void showProgressBar(boolean show) {

--- a/app/src/main/java/org/fossasia/openevent/app/event/detail/EventDetailActivityPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/event/detail/EventDetailActivityPresenter.java
@@ -16,22 +16,23 @@ import io.reactivex.schedulers.Schedulers;
 
 public class EventDetailActivityPresenter implements IEventDetailPresenter {
 
-    private long eventId;
+    private Event initialEvent;
     private IEventDetailView eventDetailView;
     private IEventDataRepository eventRepository;
 
     private long totalTickets, totalAttendees;
 
-    public EventDetailActivityPresenter(long eventId, IEventDetailView eventDetailView, IEventDataRepository eventRepository) {
-        this.eventId = eventId;
+    public EventDetailActivityPresenter(Event initialEvent, IEventDetailView eventDetailView, IEventDataRepository eventRepository) {
+        this.initialEvent = initialEvent;
         this.eventDetailView = eventDetailView;
         this.eventRepository = eventRepository;
     }
 
     @Override
     public void attach() {
-        loadAttendees(eventId, false);
-        loadTickets(eventId, false);
+        showEventInfo(initialEvent);
+        loadAttendees(initialEvent.getId(), false);
+        loadTickets(initialEvent.getId(), false);
     }
 
     @Override
@@ -57,9 +58,10 @@ public class EventDetailActivityPresenter implements IEventDetailPresenter {
                 });
     }
 
-    private void processEventAndDisplay(Event event) {
+    private void showEventInfo(Event event) {
         if(eventDetailView == null)
             return;
+
         eventDetailView.showEventName(event.getName());
 
         String[] startDate = event.getStartTime().split("T");
@@ -67,6 +69,13 @@ public class EventDetailActivityPresenter implements IEventDetailPresenter {
 
         eventDetailView.showDates(startDate[0], endDate[0]);
         eventDetailView.showTime(endDate[1]);
+    }
+
+    private void processEventAndDisplay(Event event) {
+        if(eventDetailView == null)
+            return;
+
+        showEventInfo(event);
 
         List<Ticket> tickets = event.getTickets();
 

--- a/app/src/main/java/org/fossasia/openevent/app/event/detail/EventDetailsActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/event/detail/EventDetailsActivity.java
@@ -3,6 +3,7 @@ package org.fossasia.openevent.app.event.detail;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ProgressBar;
@@ -12,6 +13,7 @@ import android.widget.Toast;
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.data.EventDataRepository;
 import org.fossasia.openevent.app.data.UtilModel;
+import org.fossasia.openevent.app.data.models.Event;
 import org.fossasia.openevent.app.event.attendees.AttendeesActivity;
 import org.fossasia.openevent.app.event.detail.contract.IEventDetailView;
 
@@ -21,6 +23,8 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public class EventDetailsActivity extends AppCompatActivity implements IEventDetailView {
+
+    public static final String EVENT_KEY = "event";
 
     @BindView(R.id.progressBar)
     ProgressBar progressBar;
@@ -50,20 +54,24 @@ public class EventDetailsActivity extends AppCompatActivity implements IEventDet
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_event_details);
 
-        ButterKnife.bind(this);
+        Event initialEvent = getIntent().getParcelableExtra(EVENT_KEY);
 
-        long id = getIntent().getLongExtra("id", 0);
+        if(initialEvent == null) {
+            Log.d("ExtrasError", "Event not passed. Returning ...");
+            finish();
+            return;
+        }
+
+        ButterKnife.bind(this);
 
         UtilModel utilModel = new UtilModel(this);
 
-        eventDetailActivityPresenter = new EventDetailActivityPresenter(id, this,
+        eventDetailActivityPresenter = new EventDetailActivityPresenter(initialEvent, this,
             new EventDataRepository(utilModel));
-
-        eventDetailActivityPresenter.attach();
 
         btnCheckIn.setOnClickListener(v -> {
             Intent intent = new Intent(EventDetailsActivity.this , AttendeesActivity.class);
-            intent.putExtra("id" , id);
+            intent.putExtra("id" , initialEvent.getId());
             startActivity(intent);
         });
 

--- a/app/src/main/java/org/fossasia/openevent/app/events/EventsActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/events/EventsActivity.java
@@ -61,11 +61,9 @@ public class EventsActivity extends AppCompatActivity implements IEventsView {
         recyclerView.setItemAnimator(new DefaultItemAnimator());
 
         UtilModel utilModel = new UtilModel(this);
-        presenter = new EventsPresenter(this,
-            new EventDataRepository(utilModel),
-            utilModel);
+        presenter = new EventsPresenter(this, new EventDataRepository(utilModel), utilModel);
 
-         presenter.attach();
+        presenter.attach();
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/openevent/app/events/EventsListAdapter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/events/EventsListAdapter.java
@@ -54,10 +54,9 @@ class EventsListAdapter extends RecyclerView.Adapter<EventsListAdapter.EventRecy
         }
 
         holder.itemView.setOnClickListener(v -> {
-            Intent i = new Intent(context, EventDetailsActivity.class);
-            i.putExtra("position", holder.getAdapterPosition());
-            i.putExtra("id", thisEvent.getId());
-            context.startActivity(i);
+            Intent intent = new Intent(context, EventDetailsActivity.class);
+            intent.putExtra(EventDetailsActivity.EVENT_KEY, thisEvent);
+            context.startActivity(intent);
         });
 
     }


### PR DESCRIPTION
Fixes #119 

- Make Event Parcelable
- Share event to EventDetailActivity to show initial information while ticket info loads

