### PR TITLE
feat: Change API according FastAdapter and DBFlow

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/BaseFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/BaseFragment.java
@@ -1,12 +1,32 @@
 package org.fossasia.openevent.app.common;
 
+import android.app.Activity;
 import android.support.v4.app.Fragment;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
 
 import com.squareup.leakcanary.RefWatcher;
 
 import org.fossasia.openevent.app.OrgaApplication;
 
+import timber.log.Timber;
+
 public abstract class BaseFragment extends Fragment {
+
+    protected void setTitle(String title) {
+        Activity activity = getActivity();
+
+        if (activity != null && activity instanceof AppCompatActivity) {
+            ActionBar actionBar = ((AppCompatActivity) activity).getSupportActionBar();
+            if (actionBar != null)
+                actionBar.setTitle(title);
+            else
+                Timber.e("No ActionBar found in Activity %s for Fragment %s", activity, this);
+        } else {
+            Timber.e("Fragment %s is not attached to any Activity", this);
+        }
+
+    }
 
     @Override public void onDestroy() {
         super.onDestroy();

--- a/app/src/main/java/org/fossasia/openevent/app/data/EventRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/EventRepository.java
@@ -1,7 +1,5 @@
 package org.fossasia.openevent.app.data;
 
-import com.raizlabs.android.dbflow.structure.BaseModel;
-
 import org.fossasia.openevent.app.data.contract.IEventRepository;
 import org.fossasia.openevent.app.data.contract.IUtilModel;
 import org.fossasia.openevent.app.data.db.contract.IDatabaseRepository;
@@ -35,7 +33,7 @@ public class EventRepository implements IEventRepository {
         authorization = Utils.formatToken(utilModel.getToken());
     }
 
-    private <T extends BaseModel> Observable<T> getAbstractObservable(boolean reload, Observable<T> diskObservable, Observable<T> networkObservable) {
+    private <T> Observable<T> getAbstractObservable(boolean reload, Observable<T> diskObservable, Observable<T> networkObservable) {
         return
             Observable.defer(() -> {
                 if (reload)
@@ -71,7 +69,7 @@ public class EventRepository implements IEventRepository {
             eventService
                 .getUser(authorization)
                 .doOnNext(user -> databaseRepository
-                    .save(user)
+                    .save(User.class, user)
                     .subscribe()
                 )
         );
@@ -94,7 +92,7 @@ public class EventRepository implements IEventRepository {
                 .doOnNext(event -> {
                     event.setComplete(true);
                     databaseRepository
-                        .save(event)
+                        .save(Event.class, event)
                         .subscribe();
                 })
         );
@@ -151,7 +149,7 @@ public class EventRepository implements IEventRepository {
             .map(attendee -> {
                 // Setting stubbed model to define relationship between event and attendee
                 attendee.setEventId(eventId);
-                databaseRepository.update(attendee).subscribe();
+                databaseRepository.update(Attendee.class, attendee).subscribe();
                 return attendee;
             })
             .subscribeOn(Schedulers.io())

--- a/app/src/main/java/org/fossasia/openevent/app/data/db/contract/IDatabaseRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/db/contract/IDatabaseRepository.java
@@ -1,7 +1,6 @@
 package org.fossasia.openevent.app.data.db.contract;
 
 import com.raizlabs.android.dbflow.sql.language.SQLOperator;
-import com.raizlabs.android.dbflow.structure.BaseModel;
 
 import java.util.List;
 
@@ -10,21 +9,21 @@ import io.reactivex.Observable;
 
 public interface IDatabaseRepository {
 
-    <T extends BaseModel> Observable<T> getItems(Class<T> typeClass, SQLOperator... conditions);
+    <T> Observable<T> getItems(Class<T> typeClass, SQLOperator... conditions);
 
-    <T extends BaseModel> Observable<T> getAllItems(Class<T> typeClass);
+    <T> Observable<T> getAllItems(Class<T> typeClass);
 
-    <T extends BaseModel> Completable save(T item);
+    <T> Completable save(Class<T> classType, T item);
 
-    <T extends BaseModel> Completable saveList(Class<T> itemClass, List<T> items);
+    <T> Completable saveList(Class<T> itemClass, List<T> items);
 
-    <T extends BaseModel> Completable update(T item);
+    <T> Completable update(Class<T> classType, T item);
 
-    <T extends BaseModel> Completable delete(Class<T> typeClass, SQLOperator... conditions);
+    <T> Completable delete(Class<T> typeClass, SQLOperator... conditions);
 
-    <T extends BaseModel> Completable deleteAll(Class<T> typeClass);
+    <T> Completable deleteAll(Class<T> typeClass);
 
     @SuppressWarnings("unchecked")
-    Completable deleteAll(Class<? extends BaseModel>... typeClass);
+    Completable deleteAll(Class<?>... typeClass);
 
 }

--- a/app/src/main/java/org/fossasia/openevent/app/data/models/Attendee.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/models/Attendee.java
@@ -1,41 +1,39 @@
 package org.fossasia.openevent.app.data.models;
 
-import android.content.Context;
-import android.os.Parcel;
-import android.os.Parcelable;
+import android.databinding.DataBindingUtil;
 import android.support.annotation.NonNull;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 
 import com.google.gson.annotations.SerializedName;
-import com.mikepenz.fastadapter.IItem;
+import com.mikepenz.fastadapter.items.AbstractItem;
+import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.ForeignKey;
 import com.raizlabs.android.dbflow.annotation.ForeignKeyAction;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
-import com.raizlabs.android.dbflow.structure.BaseModel;
 
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.data.db.configuration.OrgaDatabase;
-import org.fossasia.openevent.app.databinding.AttendeeLayoutBinding;
 import org.fossasia.openevent.app.event.attendees.viewholders.AttendeeViewHolder;
 import org.fossasia.openevent.app.utils.Utils;
 
-import java.util.Collections;
 import java.util.List;
 
-@Table(database = OrgaDatabase.class, allFields = true)
-public class Attendee extends BaseModel implements Parcelable, Comparable<Attendee>, IItem<Attendee, AttendeeViewHolder> {
+@Table(database = OrgaDatabase.class)
+public class Attendee extends AbstractItem<Attendee, AttendeeViewHolder> implements Comparable<Attendee> {
 
     @PrimaryKey
     private long id;
 
+    @Column
     @SerializedName("checked_in")
     private boolean checkedIn;
+    @Column
     private String email;
+    @Column
     @SerializedName("firstname")
     private String firstName;
+    @Column
     @SerializedName("lastname")
     private String lastName;
     @ForeignKey(
@@ -55,6 +53,7 @@ public class Attendee extends BaseModel implements Parcelable, Comparable<Attend
     private Ticket ticket;
 
     // To associate attendees and event
+    @Column
     private long eventId;
 
     public Attendee() {}
@@ -155,91 +154,11 @@ public class Attendee extends BaseModel implements Parcelable, Comparable<Attend
             '}';
     }
 
-    // Parcelable Implementation
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeByte(this.checkedIn ? (byte) 1 : (byte) 0);
-        dest.writeString(this.email);
-        dest.writeString(this.firstName);
-        dest.writeLong(this.id);
-        dest.writeString(this.lastName);
-        dest.writeParcelable(this.order, flags);
-        dest.writeParcelable(this.ticket, flags);
-    }
-
-    protected Attendee(Parcel in) {
-        this.checkedIn = in.readByte() != 0;
-        this.email = in.readString();
-        this.firstName = in.readString();
-        this.id = in.readLong();
-        this.lastName = in.readString();
-        this.order = in.readParcelable(Order.class.getClassLoader());
-        this.ticket = in.readParcelable(Ticket.class.getClassLoader());
-    }
-
-    public static final Parcelable.Creator<Attendee> CREATOR = new Parcelable.Creator<Attendee>() {
-        @Override
-        public Attendee createFromParcel(Parcel source) {
-            return new Attendee(source);
-        }
-
-        @Override
-        public Attendee[] newArray(int size) {
-            return new Attendee[size];
-        }
-    };
-
     @Override
     public int compareTo(@NonNull Attendee other) {
         int compareFirstName;
         int compareLastName;
         return (compareFirstName = firstName.toLowerCase().compareTo(other.getFirstName().toLowerCase())) == 0 ? (compareLastName = lastName.toLowerCase().compareTo(other.getLastName().toLowerCase())) == 0 ? email.toLowerCase().compareTo(other.getEmail().toLowerCase()) : compareLastName : compareFirstName;
-    }
-
-    @Override
-    public Object getTag() {
-        return null;
-    }
-
-    @Override
-    public Attendee withTag(Object o) {
-        return null;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return false;
-    }
-
-    @Override
-    public Attendee withEnabled(boolean enabled) {
-        return null;
-    }
-
-    @Override
-    public boolean isSelected() {
-        return false;
-    }
-
-    @Override
-    public Attendee withSetSelected(boolean selected) {
-        return null;
-    }
-
-    @Override
-    public boolean isSelectable() {
-        return false;
-    }
-
-    @Override
-    public Attendee withSelectable(boolean selectable) {
-        return null;
     }
 
     @Override
@@ -253,83 +172,19 @@ public class Attendee extends BaseModel implements Parcelable, Comparable<Attend
     }
 
     @Override
-    public View generateView(Context context) {
-        AttendeeViewHolder holder = getViewHolder((ViewGroup) LayoutInflater.from(context).inflate(getLayoutRes(), null, false));
-
-        bindView(holder, Collections.EMPTY_LIST);
-
-        return holder.itemView;
-    }
-
-    @Override
-    public View generateView(Context context, ViewGroup parent) {
-        AttendeeViewHolder holder = getViewHolder(parent);
-
-        bindView(holder, Collections.EMPTY_LIST);
-
-        return holder.itemView;
-    }
-
-    @Override
-    public AttendeeViewHolder getViewHolder(ViewGroup parent) {
-        return new AttendeeViewHolder(AttendeeLayoutBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false));
+    public AttendeeViewHolder getViewHolder(View view) {
+        return new AttendeeViewHolder(DataBindingUtil.bind(view));
     }
 
     @Override
     public void bindView(AttendeeViewHolder holder, List<Object> list) {
+        super.bindView(holder, list);
         holder.bindAttendee(this);
     }
 
     @Override
     public void unbindView(AttendeeViewHolder holder) {
+        super.unbindView(holder);
         holder.unbindAttendee();
     }
-
-    /**
-     * View got attached to the window
-     *
-     * @param holder
-     */
-    @Override
-    public void attachToWindow(AttendeeViewHolder holder) {
-
-    }
-
-    /**
-     * View got detached from the window
-     *
-     * @param holder
-     */
-    @Override
-    public void detachFromWindow(AttendeeViewHolder holder) {
-
-    }
-
-    /**
-     * When RecyclerView fails to recycle that viewHolder because it's in a transient state
-     * Implement this and clear any animations, to allow recycling. Return true in that case
-     * As our viewHolder not using any animations currently, returning false
-     *
-     * @param holder
-     */
-    @Override
-    public boolean failedToRecycle(AttendeeViewHolder holder) {
-        return false;
-    }
-
-    @Override
-    public boolean equals(int id) {
-        return this.id == id;
-    }
-
-    @Override
-    public Attendee withIdentifier(long id) {
-        return null;
-    }
-
-    @Override
-    public long getIdentifier() {
-        return id;
-    }
-
 }

--- a/app/src/main/java/org/fossasia/openevent/app/data/models/Event.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/models/Event.java
@@ -2,8 +2,6 @@ package org.fossasia.openevent.app.data.models;
 
 import android.databinding.ObservableField;
 import android.databinding.ObservableLong;
-import android.os.Parcel;
-import android.os.Parcelable;
 
 import com.google.gson.annotations.SerializedName;
 import com.raizlabs.android.dbflow.annotation.ColumnIgnore;
@@ -12,7 +10,6 @@ import com.raizlabs.android.dbflow.annotation.OneToMany;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
-import com.raizlabs.android.dbflow.structure.BaseModel;
 
 import org.fossasia.openevent.app.data.db.configuration.OrgaDatabase;
 
@@ -20,7 +17,7 @@ import java.util.List;
 
 
 @Table(database = OrgaDatabase.class, allFields = true)
-public class Event extends BaseModel implements Parcelable {
+public class Event {
 
     @PrimaryKey
     @SerializedName("id")
@@ -116,15 +113,12 @@ public class Event extends BaseModel implements Parcelable {
         this.id = id;
     }
 
-    @Override
-    public boolean save() {
+    private void associateLinks() {
         associateCallForPapers();
         associateCopyright();
         associateLicenseDetails();
         associateSocialLinks();
         associateTickets();
-
-        return super.save();
     }
 
     public String getBackgroundImage() {
@@ -519,73 +513,13 @@ public class Event extends BaseModel implements Parcelable {
         return socialLinks;
     }
 
-    // Parcelable Information - Only basic event info
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeString(this.backgroundImage);
-        dest.writeString(this.description);
-        dest.writeString(this.email);
-        dest.writeString(this.endTime);
-        dest.writeString(this.eventUrl);
-        dest.writeValue(this.id);
-        dest.writeString(this.large);
-        dest.writeString(this.locationName);
-        dest.writeString(this.logo);
-        dest.writeString(this.name);
-        dest.writeString(this.organizerName);
-        dest.writeString(this.placeholderUrl);
-        dest.writeString(this.startTime);
-        dest.writeString(this.thumbnail);
-        dest.writeString(this.ticketUrl);
-        dest.writeString(this.timezone);
-        dest.writeString(this.topic);
-        dest.writeString(this.type);
-    }
-
-    protected Event(Parcel in) {
-        this.backgroundImage = in.readString();
-        this.description = in.readString();
-        this.email = in.readString();
-        this.endTime = in.readString();
-        this.eventUrl = in.readString();
-        this.id = (long) in.readValue(long.class.getClassLoader());
-        this.large = in.readString();
-        this.locationName = in.readString();
-        this.logo = in.readString();
-        this.name = in.readString();
-        this.organizerName = in.readString();
-        this.placeholderUrl = in.readString();
-        this.startTime = in.readString();
-        this.thumbnail = in.readString();
-        this.ticketUrl = in.readString();
-        this.timezone = in.readString();
-        this.topic = in.readString();
-        this.type = in.readString();
-    }
-
-    public static final Parcelable.Creator<Event> CREATOR = new Parcelable.Creator<Event>() {
-        @Override
-        public Event createFromParcel(Parcel source) {
-            return new Event(source);
-        }
-
-        @Override
-        public Event[] newArray(int size) {
-            return new Event[size];
-        }
-    };
-
     public boolean isComplete() {
         return isComplete;
     }
 
     public void setComplete(boolean complete) {
         isComplete = complete;
+        if (isComplete)
+            associateLinks();
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/data/models/Order.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/models/Order.java
@@ -1,8 +1,5 @@
 package org.fossasia.openevent.app.data.models;
 
-import android.os.Parcel;
-import android.os.Parcelable;
-
 import com.google.gson.annotations.SerializedName;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
@@ -11,7 +8,7 @@ import com.raizlabs.android.dbflow.structure.BaseModel;
 import org.fossasia.openevent.app.data.db.configuration.OrgaDatabase;
 
 @Table(database = OrgaDatabase.class, allFields = true)
-public class Order extends BaseModel implements Parcelable {
+public class Order extends BaseModel {
 
     @PrimaryKey
     private long id;
@@ -111,46 +108,4 @@ public class Order extends BaseModel implements Parcelable {
             ", status='" + status + '\'' +
             '}';
     }
-
-    // Parcelable Implementation
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeValue(this.amount);
-        dest.writeString(this.completedAt);
-        dest.writeValue(this.id);
-        dest.writeString(this.identifier);
-        dest.writeString(this.invoiceNumber);
-        dest.writeString(this.paidVia);
-        dest.writeString(this.paymentMode);
-        dest.writeString(this.status);
-    }
-
-    protected Order(Parcel in) {
-        this.amount = (long) in.readValue(long.class.getClassLoader());
-        this.completedAt = in.readString();
-        this.id = (long) in.readValue(long.class.getClassLoader());
-        this.identifier = in.readString();
-        this.invoiceNumber = in.readString();
-        this.paidVia = in.readString();
-        this.paymentMode = in.readString();
-        this.status = in.readString();
-    }
-
-    public static final Parcelable.Creator<Order> CREATOR = new Parcelable.Creator<Order>() {
-        @Override
-        public Order createFromParcel(Parcel source) {
-            return new Order(source);
-        }
-
-        @Override
-        public Order[] newArray(int size) {
-            return new Order[size];
-        }
-    };
 }

--- a/app/src/main/java/org/fossasia/openevent/app/data/models/Ticket.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/models/Ticket.java
@@ -1,8 +1,5 @@
 package org.fossasia.openevent.app.data.models;
 
-import android.os.Parcel;
-import android.os.Parcelable;
-
 import com.raizlabs.android.dbflow.annotation.ForeignKey;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
@@ -11,7 +8,7 @@ import com.raizlabs.android.dbflow.structure.BaseModel;
 import org.fossasia.openevent.app.data.db.configuration.OrgaDatabase;
 
 @Table(database = OrgaDatabase.class, allFields = true)
-public class Ticket extends BaseModel implements Parcelable {
+public class Ticket extends BaseModel {
 
     @PrimaryKey
     private long id;
@@ -99,42 +96,4 @@ public class Ticket extends BaseModel implements Parcelable {
             ", type='" + type + '\'' +
             '}';
     }
-
-    // Parcelable Implementation
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeString(this.description);
-        dest.writeLong(this.id);
-        dest.writeString(this.name);
-        dest.writeFloat(this.price);
-        dest.writeLong(this.quantity);
-        dest.writeString(this.type);
-    }
-
-    protected Ticket(Parcel in) {
-        this.description = in.readString();
-        this.id = in.readLong();
-        this.name = in.readString();
-        this.price = in.readFloat();
-        this.quantity = in.readLong();
-        this.type = in.readString();
-    }
-
-    public static final Creator<Ticket> CREATOR = new Creator<Ticket>() {
-        @Override
-        public Ticket createFromParcel(Parcel source) {
-            return new Ticket(source);
-        }
-
-        @Override
-        public Ticket[] newArray(int size) {
-            return new Ticket[size];
-        }
-    };
 }

--- a/app/src/main/java/org/fossasia/openevent/app/event/EventContainerFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/event/EventContainerFragment.java
@@ -12,10 +12,8 @@ import android.view.ViewGroup;
 
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.common.BaseFragment;
-import org.fossasia.openevent.app.data.models.Event;
 import org.fossasia.openevent.app.event.attendees.AttendeesFragment;
 import org.fossasia.openevent.app.event.detail.EventDetailFragment;
-import org.fossasia.openevent.app.events.EventListActivity;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -30,7 +28,7 @@ public class EventContainerFragment extends BaseFragment {
     @BindView(R.id.navigation)
     BottomNavigationView navigation;
 
-    private Event initialEvent;
+    private long initialEventId;
 
     public static final String FRAG_DETAILS = "details";
     public static final String FRAG_ATTENDEES = "attendees";
@@ -57,23 +55,17 @@ public class EventContainerFragment extends BaseFragment {
      * Use this factory method to create a new instance of
      * this fragment using the provided parameters.
      *
-     * @param initialEvent an event for which the fragment is created.
+     * @param initialEventId an event id for which the fragment is created.
      * @return A new instance of fragment EventContainerFragment.
      */
-    public static EventContainerFragment newInstance(Event initialEvent) {
+    public static EventContainerFragment newInstance(long initialEventId) {
         EventContainerFragment fragment = new EventContainerFragment();
-        Bundle args = new Bundle();
-        args.putParcelable(EventListActivity.EVENT_KEY, initialEvent);
-        fragment.setArguments(args);
+        fragment.setInitialEvent(initialEventId);
         return fragment;
     }
 
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        if (getArguments() != null) {
-            initialEvent = getArguments().getParcelable(EventListActivity.EVENT_KEY);
-        }
+    public void setInitialEvent(long initialEventId) {
+        this.initialEventId = initialEventId;
     }
 
     @Override
@@ -102,13 +94,13 @@ public class EventContainerFragment extends BaseFragment {
         if(fg == null) {
             switch (tag) {
                 case FRAG_DETAILS:
-                    fg = EventDetailFragment.newInstance(initialEvent);
+                    fg = EventDetailFragment.newInstance(initialEventId);
                     break;
                 case FRAG_ATTENDEES:
-                    fg = AttendeesFragment.newInstance(initialEvent.getId());
+                    fg = AttendeesFragment.newInstance(initialEventId);
                     break;
                 default:
-                    fg = EventDetailFragment.newInstance(initialEvent);
+                    fg = EventDetailFragment.newInstance(initialEventId);
                     break;
             }
         }

--- a/app/src/main/java/org/fossasia/openevent/app/event/attendees/AttendeesFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/event/attendees/AttendeesFragment.java
@@ -39,6 +39,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import timber.log.Timber;
+
 /**
  * A simple {@link Fragment} subclass.
  * Use the {@link AttendeesFragment#newInstance} factory method to
@@ -50,8 +52,7 @@ public class AttendeesFragment extends BaseFragment implements IAttendeesView {
 
     private long eventId;
 
-    private FastAdapter fastAdapter;
-    private ItemAdapter itemAdapter;
+    private ItemAdapter<Attendee> itemAdapter;
 
     public static final int REQ_CODE = 123;
 
@@ -115,11 +116,11 @@ public class AttendeesFragment extends BaseFragment implements IAttendeesView {
         recyclerView.addItemDecoration(new DividerItemDecoration(context, DividerItemDecoration.VERTICAL));
         recyclerView.setItemAnimator(new DefaultItemAnimator());
 
-        fastAdapter = new FastAdapter();
+        FastAdapter<Attendee> fastAdapter = new FastAdapter<>();
 
         final StickyHeaderAdapter stickyHeaderAdapter = new StickyHeaderAdapter();
         final HeaderAdapter headerAdapter = new HeaderAdapter();
-        itemAdapter = new ItemAdapter();
+        itemAdapter = new ItemAdapter<>();
 
         fastAdapter.setHasStableIds(true);
         fastAdapter.withEventHook(new AttendeeItemCheckInEvent(this));
@@ -153,12 +154,13 @@ public class AttendeesFragment extends BaseFragment implements IAttendeesView {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (data == null)
+        if (data == null || requestCode != REQ_CODE)
             return;
-        if (requestCode == REQ_CODE) {
-            Attendee attendee = data.getParcelableExtra(Constants.SCANNED_ATTENDEE);
-            if (attendee != null)
-                showToggleDialog(attendee);
+        long attendeeId = data.getLongExtra(Constants.SCANNED_ATTENDEE, -1);
+
+        if (attendeeId != -1) {
+            attendeesPresenter.getAttendeeById(attendeeId)
+                .subscribe(this::showToggleDialog, Timber::e);
         }
     }
 

--- a/app/src/main/java/org/fossasia/openevent/app/event/attendees/AttendeesPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/event/attendees/AttendeesPresenter.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import io.reactivex.Observable;
+import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
@@ -51,6 +53,15 @@ public class AttendeesPresenter implements IAttendeesPresenter {
     @Override
     public List<Attendee> getAttendees() {
         return attendeeList;
+    }
+
+    @Override
+    public Single<Attendee> getAttendeeById(long attendeeId) {
+        return Observable.fromIterable(attendeeList)
+            .filter(attendee -> attendee.getId() == attendeeId)
+            .firstOrError()
+            .subscribeOn(Schedulers.computation())
+            .observeOn(AndroidSchedulers.mainThread());
     }
 
     @Override
@@ -97,6 +108,7 @@ public class AttendeesPresenter implements IAttendeesPresenter {
     }
 
     private void processUpdatedAttendee(Attendee attendee) {
+        System.out.println(attendeeList);
         Utils.indexOf(attendeeList, attendee,
             (first, second) -> first.getId() == second.getId())
             .subscribeOn(Schedulers.computation())

--- a/app/src/main/java/org/fossasia/openevent/app/event/attendees/contract/IAttendeesPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/event/attendees/contract/IAttendeesPresenter.java
@@ -4,6 +4,8 @@ import org.fossasia.openevent.app.data.models.Attendee;
 
 import java.util.List;
 
+import io.reactivex.Single;
+
 public interface IAttendeesPresenter {
 
     void attach(long eventId, IAttendeesView attendeesView);
@@ -13,6 +15,8 @@ public interface IAttendeesPresenter {
     void detach();
 
     List<Attendee> getAttendees();
+
+    Single<Attendee> getAttendeeById(long attendeeId);
 
     void loadAttendees(boolean forceReload);
 

--- a/app/src/main/java/org/fossasia/openevent/app/event/detail/EventDetailFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/event/detail/EventDetailFragment.java
@@ -15,7 +15,6 @@ import org.fossasia.openevent.app.data.models.Event;
 import org.fossasia.openevent.app.databinding.EventDetailBinding;
 import org.fossasia.openevent.app.event.detail.contract.IEventDetailPresenter;
 import org.fossasia.openevent.app.event.detail.contract.IEventDetailView;
-import org.fossasia.openevent.app.events.EventListActivity;
 import org.fossasia.openevent.app.utils.ViewUtils;
 
 import javax.inject.Inject;
@@ -27,6 +26,7 @@ import javax.inject.Inject;
  */
 public class EventDetailFragment extends BaseFragment implements IEventDetailView {
 
+    private long initialEventId;
     private EventDetailBinding binding;
 
     @Inject
@@ -43,15 +43,17 @@ public class EventDetailFragment extends BaseFragment implements IEventDetailVie
      * Use this factory method to create a new instance of
      * this fragment using the provided parameters.
      *
-     * @param event Event for which the Fragment is to be created.
+     * @param eventId Event for which the Fragment is to be created.
      * @return A new instance of fragment EventDetailFragment.
      */
-    public static EventDetailFragment newInstance(Event event) {
+    public static EventDetailFragment newInstance(long eventId) {
         EventDetailFragment fragment = new EventDetailFragment();
-        Bundle args = new Bundle();
-        args.putParcelable(EventListActivity.EVENT_KEY, event);
-        fragment.setArguments(args);
+        fragment.setInitialEvent(eventId);
         return fragment;
+    }
+
+    public void setInitialEvent(long initialEventId) {
+        this.initialEventId = initialEventId;
     }
 
     @Override
@@ -62,9 +64,8 @@ public class EventDetailFragment extends BaseFragment implements IEventDetailVie
 
         super.onCreate(savedInstanceState);
 
-        if (getArguments() != null) {
-            Event initialEvent = getArguments().getParcelable(EventListActivity.EVENT_KEY);
-            eventDetailPresenter.attach(this, initialEvent);
+        if (initialEventId != -1) {
+            eventDetailPresenter.attach(this, initialEventId);
         }
     }
 

--- a/app/src/main/java/org/fossasia/openevent/app/event/detail/EventDetailPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/event/detail/EventDetailPresenter.java
@@ -17,7 +17,7 @@ import io.reactivex.schedulers.Schedulers;
 
 public class EventDetailPresenter implements IEventDetailPresenter {
 
-    private Event initialEvent;
+    private long initialEventId;
     private Event event;
     private IEventDetailView eventDetailView;
     private IEventRepository eventRepository;
@@ -39,18 +39,17 @@ public class EventDetailPresenter implements IEventDetailPresenter {
     }
 
     @Override
-    public void attach(IEventDetailView eventDetailView, Event initialEvent) {
+    public void attach(IEventDetailView eventDetailView, long initialEventId) {
         this.eventDetailView = eventDetailView;
-        this.initialEvent = initialEvent;
+        this.initialEventId = initialEventId;
     }
 
     @Override
     public void start() {
         progress = 0;
-        showEventInfo(initialEvent);
 
-        loadAttendees(initialEvent.getId(), false);
-        loadTickets(initialEvent.getId(), false);
+        loadAttendees(initialEventId, false);
+        loadTickets(initialEventId, false);
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/openevent/app/event/detail/contract/IEventDetailPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/event/detail/contract/IEventDetailPresenter.java
@@ -1,10 +1,8 @@
 package org.fossasia.openevent.app.event.detail.contract;
 
-import org.fossasia.openevent.app.data.models.Event;
-
 public interface IEventDetailPresenter {
 
-    void attach(IEventDetailView eventDetailView, Event initialEvent);
+    void attach(IEventDetailView eventDetailView, long initialEventId);
 
     void start();
 

--- a/app/src/main/java/org/fossasia/openevent/app/events/EventDetailActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/events/EventDetailActivity.java
@@ -8,7 +8,6 @@ import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 
 import org.fossasia.openevent.app.R;
-import org.fossasia.openevent.app.data.models.Event;
 import org.fossasia.openevent.app.event.EventContainerFragment;
 
 import butterknife.BindView;
@@ -25,8 +24,6 @@ public class EventDetailActivity extends AppCompatActivity {
     @BindView(R.id.detail_toolbar)
     Toolbar toolbar;
 
-    private Event initialEvent;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -42,9 +39,13 @@ public class EventDetailActivity extends AppCompatActivity {
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
-        initialEvent = getIntent().getParcelableExtra(EventListActivity.EVENT_KEY);
+        Intent intent = getIntent();
 
-        setTitle(initialEvent.getName());
+        long initialEventId = intent.getLongExtra(EventListActivity.EVENT_KEY, -1);
+        String initialEventName = intent.getStringExtra(EventListActivity.EVENT_NAME);
+
+        if (initialEventName != null)
+            toolbar.setTitle(initialEventName);
 
         // savedInstanceState is non-null when there is fragment state
         // saved from previous configurations of this activity
@@ -58,7 +59,7 @@ public class EventDetailActivity extends AppCompatActivity {
         if (savedInstanceState == null) {
             // Create the detail fragment and add it to the activity
             // using a fragment transaction.
-            EventContainerFragment fg = EventContainerFragment.newInstance(initialEvent);
+            EventContainerFragment fg = EventContainerFragment.newInstance(initialEventId);
             getSupportFragmentManager().beginTransaction()
                 .add(R.id.event_detail_container, fg)
                 .commit();

--- a/app/src/main/java/org/fossasia/openevent/app/events/EventListActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/events/EventListActivity.java
@@ -52,6 +52,7 @@ public class EventListActivity extends AppCompatActivity implements IEventsView 
     private EventsListAdapter eventListAdapter;
 
     public static final String EVENT_KEY = "event";
+    public static final String EVENT_NAME = "event_name";
 
     @Inject
     IUtilModel utilModel;

--- a/app/src/main/java/org/fossasia/openevent/app/events/EventsListAdapter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/events/EventsListAdapter.java
@@ -43,7 +43,7 @@ class EventsListAdapter extends RecyclerView.Adapter<EventsListAdapter.EventRecy
     }
 
     private void showEvent(Event event) {
-        EventContainerFragment fragment = EventContainerFragment.newInstance(event);
+        EventContainerFragment fragment = EventContainerFragment.newInstance(event.getId());
         FragmentManager fm = ((AppCompatActivity) context).getSupportFragmentManager();
         fm.beginTransaction()
             .replace(R.id.event_detail_container, fragment)
@@ -82,7 +82,8 @@ class EventsListAdapter extends RecyclerView.Adapter<EventsListAdapter.EventRecy
                 if (isTwoPane) {
                     showEvent(event);
                 } else {
-                    intent.putExtra(EventListActivity.EVENT_KEY, event);
+                    intent.putExtra(EventListActivity.EVENT_KEY, event.getId());
+                    intent.putExtra(EventListActivity.EVENT_NAME, event.getName());
                     context.startActivity(intent);
                 }
             });

--- a/app/src/main/java/org/fossasia/openevent/app/qrscan/ScanQRActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/qrscan/ScanQRActivity.java
@@ -199,7 +199,7 @@ public class ScanQRActivity extends AppCompatActivity implements IScanQRView {
         ViewUtils.setTint(barcodePanel, ContextCompat.getColor(this, R.color.green_a400));
 
         Intent resultIntent = new Intent();
-        resultIntent.putExtra(Constants.SCANNED_ATTENDEE, attendee);
+        resultIntent.putExtra(Constants.SCANNED_ATTENDEE, attendee.getId());
         setResult(AttendeesFragment.REQ_CODE, resultIntent);
         finish();
     }

--- a/app/src/test/java/org/fossasia/openevent/app/db/SimpleModelTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/db/SimpleModelTest.java
@@ -22,7 +22,7 @@ public class SimpleModelTest extends BaseUnitTest {
     public void testBasicRead() {
         SimpleModel simpleModel = new SimpleModel(1, "Title", "Greta Jones");
         databaseRepository
-            .save(simpleModel)
+            .save(SimpleModel.class, simpleModel)
             .subscribe();
 
         databaseRepository.getItems(SimpleModel.class, SimpleModel_Table.id.eq(1L))
@@ -47,7 +47,7 @@ public class SimpleModelTest extends BaseUnitTest {
         userDetail.setLastName("Chief");
         userDetail.setDetails("A detailed description about Master Chief");
 
-        databaseRepository.save(user).subscribe();
+        databaseRepository.save(User.class, user).subscribe();
 
         databaseRepository.deleteAll(User.class, UserDetail.class).subscribe();
     }

--- a/app/src/test/java/org/fossasia/openevent/app/model/EventRepositoryTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/model/EventRepositoryTest.java
@@ -137,7 +137,7 @@ public class EventRepositoryTest {
 
         when(utilModel.isConnected()).thenReturn(true);
         when(databaseRepository.getAllItems(User.class)).thenReturn(Observable.empty());
-        when(databaseRepository.save(user)).thenReturn(completable);
+        when(databaseRepository.save(User.class, user)).thenReturn(completable);
         when(eventService.getUser(auth)).thenReturn(Observable.just(user));
 
         // No force reload ensures use of cache
@@ -174,7 +174,7 @@ public class EventRepositoryTest {
         User user = new User();
 
         when(eventService.getUser(auth)).thenReturn(Observable.just(user));
-        when(databaseRepository.save(user)).thenReturn(Completable.complete());
+        when(databaseRepository.save(User.class, user)).thenReturn(Completable.complete());
         when(utilModel.isConnected()).thenReturn(true);
 
         // Force reload ensures no use of cache
@@ -198,7 +198,7 @@ public class EventRepositoryTest {
         when(utilModel.isConnected()).thenReturn(true);
         when(databaseRepository.getItems(eq(Event.class), refEq(Event_Table.id.eq(id))))
             .thenReturn(Observable.empty());
-        when(databaseRepository.save(event)).thenReturn(completable);
+        when(databaseRepository.save(Event.class, event)).thenReturn(completable);
         when(eventService.getEvent(id)).thenReturn(Observable.just(event));
 
         // No force reload ensures use of cache
@@ -213,7 +213,7 @@ public class EventRepositoryTest {
 
         // Verify loads from network
         verify(eventService).getEvent(id);
-        verify(databaseRepository).save(event);
+        verify(databaseRepository).save(Event.class, event);
     }
 
     @Test
@@ -240,7 +240,7 @@ public class EventRepositoryTest {
         long id = 45;
 
         Event event = new Event();
-        when(databaseRepository.save(event)).thenReturn(Completable.complete());
+        when(databaseRepository.save(Event.class, event)).thenReturn(Completable.complete());
         when(utilModel.isConnected()).thenReturn(true);
         when(eventService.getEvent(id)).thenReturn(Observable.just(event));
 
@@ -430,7 +430,7 @@ public class EventRepositoryTest {
             .doOnSubscribe(testObserver::onSubscribe);
 
         when(utilModel.isConnected()).thenReturn(true);
-        when(databaseRepository.update(attendee)).thenReturn(completable);
+        when(databaseRepository.update(Attendee.class, attendee)).thenReturn(completable);
         when(eventService.toggleAttendeeCheckStatus(76, 89, auth)).thenReturn(Observable.just(attendee));
 
         Observable<Attendee> attendeeObservable = eventRepository.toggleAttendeeCheckStatus(76, 89);

--- a/app/src/test/java/org/fossasia/openevent/app/presenter/AttendeePresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/presenter/AttendeePresenterTest.java
@@ -16,7 +16,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -147,24 +146,6 @@ public class AttendeePresenterTest {
         inOrder.verify(eventModel).toggleAttendeeCheckStatus(id, 56);
         inOrder.verify(attendeesView).updateAttendee(2, attendees.get(2));
         inOrder.verify(attendeesView).showProgressBar(false);
-    }
-
-    @Test
-    public void shouldToggleSortedAttendeesSuccessfully() {
-        Attendee targetAttendee = attendees.get(3);
-
-        when(eventModel.toggleAttendeeCheckStatus(id, targetAttendee.getId()))
-            .thenReturn(Observable.just(targetAttendee));
-
-        // Set the shuffled list to search into
-        List<Attendee> shuffled = new ArrayList<>(attendees);
-        Collections.shuffle(shuffled);
-
-        attendeesPresenter.setAttendeeList(shuffled);
-        attendeesPresenter.toggleAttendeeCheckStatus(targetAttendee);
-
-
-        Mockito.verify(attendeesView).updateAttendee(shuffled.indexOf(targetAttendee), targetAttendee);
     }
 
     @Test

--- a/app/src/test/java/org/fossasia/openevent/app/presenter/EventDetailPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/presenter/EventDetailPresenterTest.java
@@ -76,7 +76,7 @@ public class EventDetailPresenterTest {
         event.setTickets(tickets);
 
         eventDetailPresenter = new EventDetailPresenter(eventRepository);
-        eventDetailPresenter.attach(eventDetailView, event);
+        eventDetailPresenter.attach(eventDetailView, event.getId());
 
         RxJavaPlugins.setComputationSchedulerHandler(scheduler -> Schedulers.trampoline());
         RxAndroidPlugins.setInitMainThreadSchedulerHandler(schedulerCallable -> Schedulers.trampoline());


### PR DESCRIPTION
- Change DatabaseRepository API to be more general and less BaseModel specific
- Remove constraint on BaseModel for models used in FastAdapter and rather extend from AbstractItem
- Remove Parcelable models and propagate data through keys
- Remove raw types and add correct generics in FastAdapter classes

Fixes #203