### PR TITLE
feat: Group events into live, past and upcoming

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/events/EventListActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/events/EventListActivity.java
@@ -15,6 +15,7 @@ import android.view.MenuItem;
 import android.widget.Toast;
 
 import com.android.databinding.library.baseAdapters.BR;
+import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersDecoration;
 
 import org.fossasia.openevent.app.OrgaApplication;
 import org.fossasia.openevent.app.R;
@@ -53,6 +54,7 @@ public class EventListActivity extends AppCompatActivity implements IEventsView 
 
     private final List<Event> events = new ArrayList<>();
     private EventsListAdapter eventListAdapter;
+    private RecyclerView.AdapterDataObserver adapterDataObserver;
 
     public static final String EVENT_KEY = "event";
     public static final String EVENT_NAME = "event_name";
@@ -95,6 +97,7 @@ public class EventListActivity extends AppCompatActivity implements IEventsView 
         super.onDestroy();
         presenter.detach();
         refreshLayout.setOnRefreshListener(null);
+        eventListAdapter.unregisterAdapterDataObserver(adapterDataObserver);
     }
 
     @Override
@@ -126,6 +129,16 @@ public class EventListActivity extends AppCompatActivity implements IEventsView 
         recyclerView.setAdapter(eventListAdapter);
         recyclerView.addItemDecoration(new DividerItemDecoration(this , DividerItemDecoration.VERTICAL));
         recyclerView.setItemAnimator(new DefaultItemAnimator());
+        StickyRecyclerHeadersDecoration decoration = new StickyRecyclerHeadersDecoration(eventListAdapter);
+        recyclerView.addItemDecoration(decoration);
+
+        adapterDataObserver = new RecyclerView.AdapterDataObserver() {
+            @Override
+            public void onChanged() {
+                decoration.invalidateHeaders();
+            }
+        };
+        eventListAdapter.registerAdapterDataObserver(adapterDataObserver);
     }
 
     private void setupRefreshListener() {

--- a/app/src/main/java/org/fossasia/openevent/app/events/EventsListAdapter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/events/EventsListAdapter.java
@@ -25,9 +25,13 @@ import java.util.List;
 
 class EventsListAdapter extends RecyclerView.Adapter<EventsListAdapter.EventRecyclerViewHolder> implements StickyRecyclerHeadersAdapter<EventsHeaderViewHolder>{
 
-    private static final long LIVE_EVENT = 1;
-    private final long PAST_EVENT = 2;
-    private static final long UPCOMING_EVENT = 3;
+    private static final int LIVE_EVENT = 1;
+    private static final int PAST_EVENT = 2;
+    private static final int UPCOMING_EVENT = 3;
+
+    private static final String HEADER_LIVE = "LIVE";
+    private static final String HEADER_PAST = "PAST";
+    private static final String HEADER_UPCOMING = "UPCOMING";
 
     private List<Event> events;
     private Context context;
@@ -75,21 +79,8 @@ class EventsListAdapter extends RecyclerView.Adapter<EventsListAdapter.EventRecy
     @Override
     public long getHeaderId(int position) {
         Event event = events.get(position);
-        DateUtils dateUtils = new DateUtils();
         try {
-            Date startDate = dateUtils.parse(event.getStartTime());
-            Date endDate = dateUtils.parse(event.getEndTime());
-            Date now = new Date();
-            if (now.after(startDate)) {
-                if (now.before(endDate)) {
-                    return LIVE_EVENT;
-                } else {
-                    return PAST_EVENT;
-                }
-            } else {
-                return UPCOMING_EVENT;
-            }
-
+            return getEventStatus(event);
         } catch (ParseException e) {
             e.printStackTrace();
         }
@@ -103,28 +94,41 @@ class EventsListAdapter extends RecyclerView.Adapter<EventsListAdapter.EventRecy
 
     @Override
     public void onBindHeaderViewHolder(EventsHeaderViewHolder holder, int position) {
-        final String LIVE = "LIVE";
-        final String PAST = "PAST";
-        final String UPCOMING = "UPCOMING";
-
         Event event = events.get(position);
-        DateUtils dateUtils = new DateUtils();
         try {
-            Date startDate = dateUtils.parse(event.getStartTime());
-            Date endDate = dateUtils.parse(event.getEndTime());
-            Date now = new Date();
-            if (now.after(startDate)) {
-                if (now.before(endDate)) {
-                    holder.bindHeader(LIVE);
-                } else {
-                    holder.bindHeader(PAST);
-                }
-            } else {
-                holder.bindHeader(UPCOMING);
-            }
+            switch (getEventStatus(event)) {
+                case LIVE_EVENT:
+                    holder.bindHeader(HEADER_LIVE);
+                    break;
+                case PAST_EVENT:
+                    holder.bindHeader(HEADER_PAST);
+                    break;
+                case UPCOMING_EVENT:
+                    holder.bindHeader(HEADER_UPCOMING);
+                    break;
+                default:
+                    holder.bindHeader(HEADER_LIVE);
 
+            }
         } catch (ParseException e) {
             e.printStackTrace();
+        }
+
+    }
+
+    private int getEventStatus(Event event) throws ParseException {
+        DateUtils dateUtils = new DateUtils();
+        Date startDate = dateUtils.parse(event.getStartTime());
+        Date endDate = dateUtils.parse(event.getEndTime());
+        Date now = new Date();
+        if (now.after(startDate)) {
+            if (now.before(endDate)) {
+                return LIVE_EVENT;
+            } else {
+                return PAST_EVENT;
+            }
+        } else {
+            return UPCOMING_EVENT;
         }
     }
 

--- a/app/src/main/java/org/fossasia/openevent/app/events/EventsListAdapter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/events/EventsListAdapter.java
@@ -8,15 +8,22 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
+import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersAdapter;
+
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.data.models.Event;
 import org.fossasia.openevent.app.databinding.EventLayoutBinding;
+import org.fossasia.openevent.app.databinding.EventSubheaderLayoutBinding;
 import org.fossasia.openevent.app.event.EventContainerFragment;
 import org.fossasia.openevent.app.event.detail.EventDetailActivity;
+import org.fossasia.openevent.app.events.viewholders.EventsHeaderViewHolder;
+import org.fossasia.openevent.app.utils.DateUtils;
 
+import java.text.ParseException;
+import java.util.Date;
 import java.util.List;
 
-class EventsListAdapter extends RecyclerView.Adapter<EventsListAdapter.EventRecyclerViewHolder>{
+class EventsListAdapter extends RecyclerView.Adapter<EventsListAdapter.EventRecyclerViewHolder> implements StickyRecyclerHeadersAdapter<EventsHeaderViewHolder>{
 
     private List<Event> events;
     private Context context;
@@ -59,6 +66,65 @@ class EventsListAdapter extends RecyclerView.Adapter<EventsListAdapter.EventRecy
             return;
 
         showEvent(events.get(0));
+    }
+
+    @Override
+    public long getHeaderId(int position) {
+        final long LIVE_EVENT = 1;
+        final long PAST_EVENT = 2;
+        final long UPCOMING_EVENT = 3;
+        Event event = events.get(position);
+        DateUtils dateUtils = new DateUtils();
+        try {
+            Date startDate = dateUtils.parse(event.getStartTime());
+            Date endDate = dateUtils.parse(event.getEndTime());
+            Date now = new Date();
+            if (now.after(startDate)) {
+                if (now.before(endDate)) {
+                    return LIVE_EVENT;
+                } else {
+                    return PAST_EVENT;
+                }
+            } else {
+                return UPCOMING_EVENT;
+            }
+
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    @Override
+    public EventsHeaderViewHolder onCreateHeaderViewHolder(ViewGroup viewGroup) {
+        return new EventsHeaderViewHolder(EventSubheaderLayoutBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false));
+    }
+
+    @Override
+    public void onBindHeaderViewHolder(EventsHeaderViewHolder holder, int position) {
+        final String LIVE = "LIVE";
+        final String PAST = "PAST";
+        final String UPCOMING = "UPCOMING";
+
+        Event event = events.get(position);
+        DateUtils dateUtils = new DateUtils();
+        try {
+            Date startDate = dateUtils.parse(event.getStartTime());
+            Date endDate = dateUtils.parse(event.getEndTime());
+            Date now = new Date();
+            if (now.after(startDate)) {
+                if (now.before(endDate)) {
+                    holder.bindHeader(LIVE);
+                } else {
+                    holder.bindHeader(PAST);
+                }
+            } else {
+                holder.bindHeader(UPCOMING);
+            }
+
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/openevent/app/events/EventsListAdapter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/events/EventsListAdapter.java
@@ -25,6 +25,10 @@ import java.util.List;
 
 class EventsListAdapter extends RecyclerView.Adapter<EventsListAdapter.EventRecyclerViewHolder> implements StickyRecyclerHeadersAdapter<EventsHeaderViewHolder>{
 
+    private static final long LIVE_EVENT = 1;
+    private final long PAST_EVENT = 2;
+    private static final long UPCOMING_EVENT = 3;
+
     private List<Event> events;
     private Context context;
 
@@ -70,9 +74,6 @@ class EventsListAdapter extends RecyclerView.Adapter<EventsListAdapter.EventRecy
 
     @Override
     public long getHeaderId(int position) {
-        final long LIVE_EVENT = 1;
-        final long PAST_EVENT = 2;
-        final long UPCOMING_EVENT = 3;
         Event event = events.get(position);
         DateUtils dateUtils = new DateUtils();
         try {

--- a/app/src/main/java/org/fossasia/openevent/app/events/EventsPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/events/EventsPresenter.java
@@ -8,6 +8,7 @@ import org.fossasia.openevent.app.utils.Utils;
 
 import javax.inject.Inject;
 
+import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 
 public class EventsPresenter implements IEventsPresenter {
@@ -56,7 +57,8 @@ public class EventsPresenter implements IEventsPresenter {
 
         eventsDataRepository
             .getEvents(forceReload)
-            .toList()
+            .toSortedList()
+            .subscribeOn(Schedulers.computation())
             .subscribe(events -> {
                 if(eventsView == null)
                     return;

--- a/app/src/main/java/org/fossasia/openevent/app/events/viewholders/EventsHeaderViewHolder.java
+++ b/app/src/main/java/org/fossasia/openevent/app/events/viewholders/EventsHeaderViewHolder.java
@@ -1,0 +1,20 @@
+package org.fossasia.openevent.app.events.viewholders;
+
+import android.support.v7.widget.RecyclerView;
+
+import org.fossasia.openevent.app.databinding.EventSubheaderLayoutBinding;
+
+public class EventsHeaderViewHolder extends RecyclerView.ViewHolder {
+
+    private EventSubheaderLayoutBinding binding;
+
+    public EventsHeaderViewHolder(EventSubheaderLayoutBinding binding) {
+        super(binding.getRoot());
+        this.binding = binding;
+    }
+
+    public void bindHeader(String header) {
+        binding.setSubheading(header);
+        binding.executePendingBindings();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/utils/DateUtils.java
+++ b/app/src/main/java/org/fossasia/openevent/app/utils/DateUtils.java
@@ -5,14 +5,12 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
-import java.util.TimeZone;
 
 public class DateUtils {
     private DateFormat dateFormat;
 
     public DateUtils() {
-        dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ENGLISH);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault());
     }
 
     public Date parse(String dateString) throws ParseException {

--- a/app/src/main/java/org/fossasia/openevent/app/utils/DateUtils.java
+++ b/app/src/main/java/org/fossasia/openevent/app/utils/DateUtils.java
@@ -1,0 +1,25 @@
+package org.fossasia.openevent.app.utils;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class DateUtils {
+    private DateFormat dateFormat;
+
+    public DateUtils() {
+        dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ENGLISH);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    public Date parse(String dateString) throws ParseException {
+        return dateFormat.parse(dateString);
+    }
+
+    public String format(Date date) {
+        return dateFormat.format(date);
+    }
+}

--- a/app/src/main/res/layout/event_layout.xml
+++ b/app/src/main/res/layout/event_layout.xml
@@ -18,7 +18,8 @@
         android:paddingLeft="@dimen/spacing_normal"
         android:paddingRight="@dimen/spacing_normal"
         android:paddingStart="@dimen/spacing_normal"
-        android:paddingTop="@dimen/spacing_small">
+        android:paddingTop="@dimen/spacing_small"
+        android:gravity="center_vertical">
 
         <ImageView
             android:layout_width="@dimen/image_small"
@@ -27,15 +28,15 @@
             app:circleImageUrl="@{event.thumbnail}" />
 
         <TextView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center_vertical"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:paddingEnd="@dimen/spacing_medium"
             android:paddingLeft="@dimen/spacing_medium"
             android:paddingRight="@dimen/spacing_medium"
             android:paddingStart="@dimen/spacing_medium"
             android:text="@{event.name}"
-            android:textAppearance="@style/Base.TextAppearance.AppCompat.Title" />
+            android:textSize="@dimen/text_size_normal"
+            android:textColor="@android:color/black"/>
 
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/event_subheader_layout.xml
+++ b/app/src/main/res/layout/event_subheader_layout.xml
@@ -6,7 +6,8 @@
     </data>
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:orientation="vertical" android:layout_width="match_parent"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:paddingTop="@dimen/spacing_small"
         android:paddingLeft="@dimen/spacing_normal"

--- a/app/src/main/res/layout/event_subheader_layout.xml
+++ b/app/src/main/res/layout/event_subheader_layout.xml
@@ -2,13 +2,12 @@
 <layout>
 
     <data>
-        <variable name="subheading" type="String"/>
+        <variable name="subheading" type="String" />
     </data>
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
+        android:orientation="vertical" android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:paddingTop="@dimen/spacing_small"
         android:paddingLeft="@dimen/spacing_normal"
         android:paddingRight="@dimen/spacing_normal"
@@ -22,6 +21,8 @@
             android:layout_height="wrap_content"
             android:textColor="@color/color_primary_dark"
             android:text="@{subheading}"
-            android:textSize="@dimen/text_size_small" />
+            android:textSize="@dimen/text_size_small"
+            android:textAllCaps="true"/>
+
     </LinearLayout>
 </layout>

--- a/app/src/test/java/org/fossasia/openevent/app/presenter/AttendeePresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/presenter/AttendeePresenterTest.java
@@ -160,15 +160,15 @@ public class AttendeePresenterTest {
     @Test
     public void shouldShowEmptyViewOnNoItemAfterSwipeRefresh() {
         ArrayList<Attendee> attendees = new ArrayList<>();
-        when(eventModel.getAttendees(id, true))
+        when(eventRepository.getAttendees(id, true))
             .thenReturn(Observable.fromIterable(attendees));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, attendeesView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, attendeesView);
 
         attendeesPresenter.loadAttendees(true);
 
         inOrder.verify(attendeesView).showEmptyView(false);
-        inOrder.verify(eventModel).getAttendees(id, true);
+        inOrder.verify(eventRepository).getAttendees(id, true);
         inOrder.verify(attendeesView).showAttendees(attendees);
         inOrder.verify(attendeesView).showEmptyView(true);
         inOrder.verify(attendeesView).onRefreshComplete();
@@ -177,15 +177,15 @@ public class AttendeePresenterTest {
     @Test
     public void shouldShowEmptyViewOnSwipeRefreshError() {
         String error = "Test Error";
-        when(eventModel.getAttendees(id, true))
+        when(eventRepository.getAttendees(id, true))
             .thenReturn(Observable.error(new Throwable(error)));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, attendeesView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, attendeesView);
 
         attendeesPresenter.loadAttendees(true);
 
         inOrder.verify(attendeesView).showEmptyView(false);
-        inOrder.verify(eventModel).getAttendees(id, true);
+        inOrder.verify(eventRepository).getAttendees(id, true);
         inOrder.verify(attendeesView).showErrorMessage(error);
         inOrder.verify(attendeesView).showEmptyView(true);
         inOrder.verify(attendeesView).onRefreshComplete();
@@ -196,15 +196,15 @@ public class AttendeePresenterTest {
         attendeesPresenter.setAttendeeList(attendees);
 
         String error = "Test Error";
-        when(eventModel.getAttendees(id, true))
+        when(eventRepository.getAttendees(id, true))
             .thenReturn(Observable.error(new Throwable(error)));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, attendeesView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, attendeesView);
 
         attendeesPresenter.loadAttendees(true);
 
         inOrder.verify(attendeesView).showEmptyView(false);
-        inOrder.verify(eventModel).getAttendees(id, true);
+        inOrder.verify(eventRepository).getAttendees(id, true);
         inOrder.verify(attendeesView).showErrorMessage(error);
         inOrder.verify(attendeesView).showEmptyView(false);
         inOrder.verify(attendeesView).onRefreshComplete();
@@ -212,15 +212,15 @@ public class AttendeePresenterTest {
 
     @Test
     public void shouldNotShowEmptyViewOnSwipeRefreshSuccess() {
-        when(eventModel.getAttendees(id, true))
+        when(eventRepository.getAttendees(id, true))
             .thenReturn(Observable.fromIterable(attendees));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, attendeesView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, attendeesView);
 
         attendeesPresenter.loadAttendees(true);
 
         inOrder.verify(attendeesView).showEmptyView(false);
-        inOrder.verify(eventModel).getAttendees(id, true);
+        inOrder.verify(eventRepository).getAttendees(id, true);
         inOrder.verify(attendeesView).showAttendees(attendees);
         inOrder.verify(attendeesView).showEmptyView(false);
         inOrder.verify(attendeesView).onRefreshComplete();

--- a/app/src/test/java/org/fossasia/openevent/app/presenter/EventsPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/presenter/EventsPresenterTest.java
@@ -7,6 +7,7 @@ import org.fossasia.openevent.app.data.models.User;
 import org.fossasia.openevent.app.data.models.UserDetail;
 import org.fossasia.openevent.app.events.EventsPresenter;
 import org.fossasia.openevent.app.events.contract.IEventsView;
+import org.fossasia.openevent.app.utils.DateUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -19,6 +20,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 import io.reactivex.Completable;
@@ -51,10 +53,13 @@ public class EventsPresenterTest {
 
     private EventsPresenter eventsActivityPresenter;
 
+    private DateUtils dateUtils = new DateUtils();
+    private String date = dateUtils.format(new Date());
+
     private List<Event> eventList = Arrays.asList(
-        new Event(12),
-        new Event(13),
-        new Event(14)
+        new Event(12, date, date),
+        new Event(13, date, date),
+        new Event(14, date, date)
     );
 
     private User organiser = new User();

--- a/app/src/test/java/org/fossasia/openevent/app/presenter/EventsPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/presenter/EventsPresenterTest.java
@@ -50,7 +50,7 @@ public class EventsPresenterTest {
     IEventsView eventListView;
 
     @Mock
-    IEventRepository eventModel;
+    IEventRepository eventRepository;
 
     @Mock
     ILoginModel loginModel;
@@ -72,7 +72,7 @@ public class EventsPresenterTest {
     public void setUp() {
         RxJavaPlugins.setComputationSchedulerHandler(scheduler -> Schedulers.trampoline());
 
-        eventsActivityPresenter = new EventsPresenter(eventModel, loginModel);
+        eventsActivityPresenter = new EventsPresenter(eventRepository, loginModel);
         eventsActivityPresenter.attach(eventListView);
     }
 
@@ -83,16 +83,16 @@ public class EventsPresenterTest {
 
     @Test
     public void shouldLoadEventsAndOrganiserAutomatically() {
-        when(eventModel.getOrganiser(false))
+        when(eventRepository.getOrganiser(false))
             .thenReturn(Observable.just(organiser));
 
-        when(eventModel.getEvents(false))
+        when(eventRepository.getEvents(false))
             .thenReturn(Observable.fromIterable(eventList));
 
         eventsActivityPresenter.start();
 
-        verify(eventModel).getEvents(false);
-        verify(eventModel).getOrganiser(false);
+        verify(eventRepository).getEvents(false);
+        verify(eventRepository).getOrganiser(false);
     }
 
     @Test
@@ -106,30 +106,30 @@ public class EventsPresenterTest {
 
     @Test
     public void shouldLoadEventsSuccessfully() {
-        when(eventModel.getEvents(false))
+        when(eventRepository.getEvents(false))
             .thenReturn(Observable.fromIterable(eventList));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, eventListView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, eventListView);
 
         eventsActivityPresenter.loadUserEvents(false);
 
         inOrder.verify(eventListView).showProgressBar(true);
-        inOrder.verify(eventModel).getEvents(false);
+        inOrder.verify(eventRepository).getEvents(false);
         inOrder.verify(eventListView).showEvents(eventList);
         inOrder.verify(eventListView).showProgressBar(false);
     }
 
     @Test
     public void shouldRefreshEventsSuccessfully() {
-        when(eventModel.getEvents(true))
+        when(eventRepository.getEvents(true))
             .thenReturn(Observable.fromIterable(eventList));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, eventListView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, eventListView);
 
         eventsActivityPresenter.loadUserEvents(true);
 
         inOrder.verify(eventListView).showProgressBar(true);
-        inOrder.verify(eventModel).getEvents(true);
+        inOrder.verify(eventRepository).getEvents(true);
         inOrder.verify(eventListView).showEvents(eventList);
         inOrder.verify(eventListView).showProgressBar(false);
         inOrder.verify(eventListView).onRefreshComplete();
@@ -138,15 +138,15 @@ public class EventsPresenterTest {
     @Test
     public void shouldShowEmptyViewOnNoItemAfterSwipeRefresh() {
         ArrayList<Event> events = new ArrayList<>();
-        when(eventModel.getEvents(true))
+        when(eventRepository.getEvents(true))
             .thenReturn(Observable.fromIterable(events));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, eventListView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, eventListView);
 
         eventsActivityPresenter.loadUserEvents(true);
 
         inOrder.verify(eventListView).showEmptyView(false);
-        inOrder.verify(eventModel).getEvents(true);
+        inOrder.verify(eventRepository).getEvents(true);
         inOrder.verify(eventListView).showEvents(events);
         inOrder.verify(eventListView).showEmptyView(true);
         inOrder.verify(eventListView).onRefreshComplete();
@@ -154,15 +154,15 @@ public class EventsPresenterTest {
 
     @Test
     public void shouldShowEmptyViewOnSwipeRefreshError() {
-        when(eventModel.getEvents(true))
+        when(eventRepository.getEvents(true))
             .thenReturn(Observable.error(new Throwable("Error")));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, eventListView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, eventListView);
 
         eventsActivityPresenter.loadUserEvents(true);
 
         inOrder.verify(eventListView).showEmptyView(false);
-        inOrder.verify(eventModel).getEvents(true);
+        inOrder.verify(eventRepository).getEvents(true);
         inOrder.verify(eventListView).showEventError(anyString());
         inOrder.verify(eventListView).showEmptyView(true);
         inOrder.verify(eventListView).onRefreshComplete();
@@ -170,15 +170,15 @@ public class EventsPresenterTest {
 
     @Test
     public void shouldNotShowEmptyViewOnSwipeRefreshSuccess() {
-        when(eventModel.getEvents(true))
+        when(eventRepository.getEvents(true))
             .thenReturn(Observable.fromIterable(eventList));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, eventListView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, eventListView);
 
         eventsActivityPresenter.loadUserEvents(true);
 
         inOrder.verify(eventListView).showEmptyView(false);
-        inOrder.verify(eventModel).getEvents(true);
+        inOrder.verify(eventRepository).getEvents(true);
         inOrder.verify(eventListView).showEvents(eventList);
         inOrder.verify(eventListView).showEmptyView(false);
         inOrder.verify(eventListView).onRefreshComplete();
@@ -186,15 +186,15 @@ public class EventsPresenterTest {
 
     @Test
     public void shouldRefreshEventsOnError() {
-        when(eventModel.getEvents(true))
+        when(eventRepository.getEvents(true))
             .thenReturn(Observable.error(new Throwable("Error")));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, eventListView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, eventListView);
 
         eventsActivityPresenter.loadUserEvents(true);
 
         inOrder.verify(eventListView).showProgressBar(true);
-        inOrder.verify(eventModel).getEvents(true);
+        inOrder.verify(eventRepository).getEvents(true);
         inOrder.verify(eventListView).showEventError(anyString());
         inOrder.verify(eventListView).showProgressBar(false);
         inOrder.verify(eventListView).onRefreshComplete();
@@ -202,7 +202,7 @@ public class EventsPresenterTest {
 
     @Test
     public void shouldNotLoadInitialEventIfNotTwoPane() {
-        when(eventModel.getEvents(false))
+        when(eventRepository.getEvents(false))
             .thenReturn(Observable.fromIterable(eventList));
         when(eventListView.isTwoPane())
             .thenReturn(false);
@@ -214,7 +214,7 @@ public class EventsPresenterTest {
 
     @Test
     public void shouldLoadInitialEventFirstTimeIfTwoPane() {
-        when(eventModel.getEvents(false))
+        when(eventRepository.getEvents(false))
             .thenReturn(Observable.fromIterable(eventList));
         when(eventListView.isTwoPane())
             .thenReturn(true);
@@ -226,7 +226,7 @@ public class EventsPresenterTest {
 
     @Test
     public void shouldNotLoadInitialEventSecondTimeIfTwoPane() {
-        when(eventModel.getEvents(false))
+        when(eventRepository.getEvents(false))
             .thenReturn(Observable.fromIterable(eventList));
         when(eventListView.isTwoPane())
             .thenReturn(true);
@@ -240,15 +240,15 @@ public class EventsPresenterTest {
     @Test
     public void shouldShowEventError() {
         String error = "Test Error";
-        when(eventModel.getEvents(false))
+        when(eventRepository.getEvents(false))
             .thenReturn(Observable.error(new Throwable(error)));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, eventListView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, eventListView);
 
         eventsActivityPresenter.loadUserEvents(false);
 
         inOrder.verify(eventListView).showProgressBar(true);
-        inOrder.verify(eventModel).getEvents(false);
+        inOrder.verify(eventRepository).getEvents(false);
         inOrder.verify(eventListView).showEventError(error);
         inOrder.verify(eventListView).showProgressBar(false);
     }
@@ -261,13 +261,13 @@ public class EventsPresenterTest {
 
         organiser.setUserDetail(userDetail);
 
-        when(eventModel.getOrganiser(false)).thenReturn(Observable.just(organiser));
+        when(eventRepository.getOrganiser(false)).thenReturn(Observable.just(organiser));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, eventListView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, eventListView);
 
         eventsActivityPresenter.loadOrganiser(false);
 
-        inOrder.verify(eventModel).getOrganiser(false);
+        inOrder.verify(eventRepository).getOrganiser(false);
         inOrder.verify(eventListView).showOrganiserName("John Wick");
     }
 
@@ -279,7 +279,7 @@ public class EventsPresenterTest {
 
         organiser.setUserDetail(userDetail);
 
-        when(eventModel.getOrganiser(false)).thenReturn(Observable.just(organiser));
+        when(eventRepository.getOrganiser(false)).thenReturn(Observable.just(organiser));
 
         eventsActivityPresenter.loadOrganiser(false);
         verify(eventListView).showOrganiserName("John Wick");
@@ -306,14 +306,14 @@ public class EventsPresenterTest {
     @Test
     public void shouldShowOrganiserError() {
         String error = "Test Error";
-        when(eventModel.getOrganiser(false))
+        when(eventRepository.getOrganiser(false))
             .thenReturn(Observable.error(new Throwable(error)));
 
-        InOrder inOrder = Mockito.inOrder(eventModel, eventListView);
+        InOrder inOrder = Mockito.inOrder(eventRepository, eventListView);
 
         eventsActivityPresenter.loadOrganiser(false);
 
-        inOrder.verify(eventModel).getOrganiser(false);
+        inOrder.verify(eventRepository).getOrganiser(false);
         inOrder.verify(eventListView).showOrganiserLoadError(error);
     }
 

--- a/app/src/test/java/org/fossasia/openevent/app/presenter/EventsPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/presenter/EventsPresenterTest.java
@@ -8,6 +8,7 @@ import org.fossasia.openevent.app.data.models.UserDetail;
 import org.fossasia.openevent.app.events.EventsPresenter;
 import org.fossasia.openevent.app.events.contract.IEventsView;
 import org.fossasia.openevent.app.utils.DateUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,6 +27,8 @@ import java.util.List;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -66,8 +69,15 @@ public class EventsPresenterTest {
 
     @Before
     public void setUp() {
+        RxJavaPlugins.setComputationSchedulerHandler(scheduler -> Schedulers.trampoline());
+
         eventsActivityPresenter = new EventsPresenter(eventModel, loginModel);
         eventsActivityPresenter.attach(eventListView);
+    }
+
+    @After
+    public void tearDown() {
+        RxJavaPlugins.reset();
     }
 
     @Test


### PR DESCRIPTION
- Implements comparable interface on event model
    - sorts events in order of live, upcoming and past
    - for both past, lately ended will be before in list
    - for both live, lately started will be before in list
    - for both upcoming earliest will be before
- Implements sticky header adapter on eventslistadapter
- Modifies event layout

fixes #152

![screenshot_2017-06-23-18-13-57](https://user-images.githubusercontent.com/13533840/27483283-5d7f33f8-5842-11e7-8f31-a4e7c186777a.png)

