### PR TITLE
fix: clearing database on different user login

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/data/LoginModel.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/LoginModel.java
@@ -1,12 +1,14 @@
 package org.fossasia.openevent.app.data;
 
+import android.support.annotation.VisibleForTesting;
+
 import org.fossasia.openevent.app.data.contract.ILoginModel;
 import org.fossasia.openevent.app.data.contract.IUtilModel;
 import org.fossasia.openevent.app.data.db.contract.IDatabaseRepository;
 import org.fossasia.openevent.app.data.models.Login;
-import org.fossasia.openevent.app.data.models.LoginResponse;
 import org.fossasia.openevent.app.data.models.User;
 import org.fossasia.openevent.app.data.network.EventService;
+import org.fossasia.openevent.app.data.repository.contract.IEventRepository;
 import org.fossasia.openevent.app.main.MainActivity;
 import org.fossasia.openevent.app.utils.Constants;
 import org.fossasia.openevent.app.utils.JWTUtils;
@@ -14,47 +16,66 @@ import org.fossasia.openevent.app.utils.JWTUtils;
 import javax.inject.Inject;
 
 import io.reactivex.Completable;
-import io.reactivex.Observable;
+import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
 public class LoginModel implements ILoginModel {
 
-    private IUtilModel utilModel;
-    private EventService eventService;
-    private IDatabaseRepository databaseRepository;
+    private static final User EMPTY = new User();
+
+    private final IUtilModel utilModel;
+    private final EventService eventService;
+    private final IEventRepository eventRepository;
+    private final IDatabaseRepository databaseRepository;
 
     @Inject
-    public LoginModel(IUtilModel utilModel, EventService eventService, IDatabaseRepository databaseRepository) {
+    public LoginModel(IUtilModel utilModel, EventService eventService, IEventRepository eventRepository, IDatabaseRepository databaseRepository) {
         this.utilModel = utilModel;
         this.eventService = eventService;
+        this.eventRepository = eventRepository;
         this.databaseRepository = databaseRepository;
     }
 
     @Override
-    public Observable<LoginResponse> login(String username, String password) {
-        if(isLoggedIn()) {
-            return Observable.just(new LoginResponse(utilModel.getToken()));
-        }
+    public Completable login(String username, String password) {
+        if(isLoggedIn())
+            return Completable.complete();
 
-        if(!utilModel.isConnected()) {
-            return Observable.error(new RuntimeException(Constants.NO_NETWORK));
-        }
+        if(!utilModel.isConnected())
+            return Completable.error(new RuntimeException(Constants.NO_NETWORK));
 
         return eventService
-                .login(new Login(username, password))
-                .doOnNext(loginResponse -> utilModel.saveToken(loginResponse.getAccessToken()))
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .doOnComplete(() ->
-                    databaseRepository.getAllItems(User.class)
-                    .any(user -> !user.getEmail().equals(username))
-                    .filter(differentUser -> differentUser)
-                    .subscribeOn(Schedulers.io())
-                    .subscribe(differentUser ->
-                        utilModel.deleteDatabase()
-                            .subscribe()
-                    ));
+            .login(new Login(username, password))
+            .flatMapSingle(loginResponse -> {
+                utilModel.saveToken(loginResponse.getAccessToken());
+                utilModel.addStringSetElement(Constants.SHARED_PREFS_SAVED_EMAIL, username);
+
+                return isPreviousUser();
+            })
+            .flatMapCompletable(isPrevious -> {
+                if (!isPrevious)
+                    return utilModel.deleteDatabase();
+
+                return Completable.complete();
+            })
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread());
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    public Single<Boolean> isPreviousUser() {
+        return databaseRepository.getAllItems(User.class)
+            .first(EMPTY)
+            .flatMap(user -> {
+                if (user.equals(EMPTY))
+                    return Single.just(false);
+
+                return eventRepository.getOrganiser(true)
+                    .firstElement()
+                    .map(user::equals)
+                    .toSingle();
+            });
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/openevent/app/data/contract/ILoginModel.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/contract/ILoginModel.java
@@ -1,13 +1,10 @@
 package org.fossasia.openevent.app.data.contract;
 
-import org.fossasia.openevent.app.data.models.LoginResponse;
-
 import io.reactivex.Completable;
-import io.reactivex.Observable;
 
 public interface ILoginModel {
 
-    Observable<LoginResponse> login(String username, String password);
+    Completable login(String username, String password);
 
     boolean isLoggedIn();
 

--- a/app/src/main/java/org/fossasia/openevent/app/data/models/User.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/models/User.java
@@ -9,9 +9,15 @@ import com.raizlabs.android.dbflow.annotation.Table;
 
 import org.fossasia.openevent.app.data.db.configuration.OrgaDatabase;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@Builder
+@AllArgsConstructor
+@EqualsAndHashCode(of = {"id", "email"})
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @Table(database = OrgaDatabase.class, allFields = true)
 public class User {

--- a/app/src/main/java/org/fossasia/openevent/app/login/LoginPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/login/LoginPresenter.java
@@ -1,8 +1,10 @@
 package org.fossasia.openevent.app.login;
 
+import android.support.annotation.VisibleForTesting;
+
 import org.fossasia.openevent.app.data.contract.ILoginModel;
-import org.fossasia.openevent.app.data.network.HostSelectionInterceptor;
 import org.fossasia.openevent.app.data.contract.IUtilModel;
+import org.fossasia.openevent.app.data.network.HostSelectionInterceptor;
 import org.fossasia.openevent.app.login.contract.ILoginPresenter;
 import org.fossasia.openevent.app.login.contract.ILoginView;
 import org.fossasia.openevent.app.utils.Constants;
@@ -52,10 +54,9 @@ public class LoginPresenter implements ILoginPresenter {
         loginView.showProgressBar(true);
 
         loginModel.login(email, password)
-            .subscribe(loginResponse -> {
+            .subscribe(() -> {
                 if(loginView != null) {
                     loginView.onLoginSuccess();
-                    saveEmail(email);
                     loginView.showProgressBar(false);
                 }
             }, throwable -> {
@@ -75,14 +76,11 @@ public class LoginPresenter implements ILoginPresenter {
         }
     }
 
-    private void saveEmail(String email) {
-        utilModel.addStringSetElement(Constants.SHARED_PREFS_SAVED_EMAIL, email);
-    }
-
     private Set<String> getEmailList() {
         return utilModel.getStringSet(Constants.SHARED_PREFS_SAVED_EMAIL, null);
     }
 
+    @VisibleForTesting
     public ILoginView getView() {
         return loginView;
     }

--- a/app/src/test/java/org/fossasia/openevent/app/presenter/LoginPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/presenter/LoginPresenterTest.java
@@ -2,7 +2,6 @@ package org.fossasia.openevent.app.presenter;
 
 import org.fossasia.openevent.app.data.contract.ILoginModel;
 import org.fossasia.openevent.app.data.contract.IUtilModel;
-import org.fossasia.openevent.app.data.models.LoginResponse;
 import org.fossasia.openevent.app.login.LoginPresenter;
 import org.fossasia.openevent.app.login.contract.ILoginView;
 import org.fossasia.openevent.app.utils.Constants;
@@ -21,7 +20,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import io.reactivex.Observable;
+import io.reactivex.Completable;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -102,9 +101,10 @@ public class LoginPresenterTest {
 
     @Test
     public void shouldLoginSuccessfully() {
-        String authToken = "testToken";
         Mockito.when(loginModel.login(email, password))
-            .thenReturn(Observable.just(new LoginResponse(authToken)));
+            .thenReturn(Completable.complete());
+        Mockito.when(utilModel.deleteDatabase())
+            .thenReturn(Completable.complete());
 
         InOrder inOrder = Mockito.inOrder(loginModel, loginView);
 
@@ -121,7 +121,7 @@ public class LoginPresenterTest {
     public void shouldShowLoginError() {
         String error = "Test Error";
         Mockito.when(loginModel.login(email, password))
-            .thenReturn(Observable.error(new Throwable(error)));
+            .thenReturn(Completable.error(new Throwable(error)));
 
         InOrder inOrder = Mockito.inOrder(loginModel, loginView);
 
@@ -141,22 +141,6 @@ public class LoginPresenterTest {
         loginPresenter.login(email, password);
 
         Mockito.verifyNoMoreInteractions(loginView);
-    }
-
-    @Test
-    public void shouldAttachEmailOnLoginSuccessfully() {
-        String authToken = "testToken";
-
-        Mockito.when(loginModel.login(email, password))
-            .thenReturn(Observable.just(new LoginResponse(authToken)));
-
-        Mockito.when(utilModel.getStringSet(Constants.SHARED_PREFS_SAVED_EMAIL, null))
-            .thenReturn(savedEmails);
-
-        loginPresenter.attach(loginView);
-        loginPresenter.login(email, password);
-
-        Mockito.verify(loginView).attachEmails(savedEmails);
     }
 
     @Test


### PR DESCRIPTION
- method `LoginModel::login` is modified to just get access token
- new method `LoginModel::isPreviousUser` is added to check different user login
- method `LoginPresenter::login` is modified accordingly to clear database on different user login and starts data loading after that only.

fixes #252