### PR TITLE
fix: drawer item styling

### DIFF
--- a/app/src/main/res/drawable/bottom_nav_tint.xml
+++ b/app/src/main/res/drawable/bottom_nav_tint.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_checked="true" android:color="@color/color_primary_dark" />
-    <item android:color="@android:color/darker_gray"  />
-</selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -19,6 +19,8 @@
         android:layout_height="match_parent"
         android:layout_gravity="start"
         android:fitsSystemWindows="true"
+        app:itemIconTint="@color/tint_drawer_item_icon"
+        app:itemTextColor="@color/color_drawer_item_text"
         app:headerLayout="@layout/nav_header_main"
         app:menu="@menu/activity_main_drawer" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -18,4 +18,6 @@
     <color name="translucent_dark">#11000000</color>
     <color name="color_top_surface">#EEEEEE</color>
     <color name="color_bottom_surface">#e6e6e6</color>
+    <color name="tint_drawer_item_icon">#8C000000</color>
+    <color name="color_drawer_item_text">#D9000000</color>
 </resources>


### PR DESCRIPTION
- sets icon and text color according to material design guideline.
- removes unused bottom navigation selectable color drawable.

fixes #282

![unnamed](https://user-images.githubusercontent.com/13533840/27962066-5d58f99c-634e-11e7-9033-37114a3a9c4c.png)
