### PR TITLE
fix: modify navigation drawer

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/main/MainActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/main/MainActivity.java
@@ -78,6 +78,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         toggle.syncState();
 
         navigationView.setNavigationItemSelectedListener(this);
+        
+        navigationView.getMenu().setGroupVisible(R.id.subMenu, false);
         fragmentManager = getSupportFragmentManager();
         loadFragment(R.id.nav_events);
 
@@ -118,6 +120,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     @Override
     public void loadDashboard(long eventId) {
+        navigationView.getMenu().setGroupVisible(R.id.subMenu, true);
         this.eventId = eventId;
         loadFragment(R.id.nav_dashboard);
     }

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -10,13 +10,16 @@
             android:id="@+id/nav_attendees"
             android:icon="@drawable/ic_attendees"
             android:title="Attendees" />
+    </group>
+
+    <group android:id="@+id/eventsMenu" android:checkableBehavior="single">
         <item
             android:id="@+id/nav_events"
             android:icon="@drawable/ic_events"
             android:title="Events" />
     </group>
 
-    <group android:id="@+id/mainMenu" android:checkableBehavior="single">
+    <group android:id="@+id/mainMenu">
 
         <item
             android:id="@+id/nav_logout"


### PR DESCRIPTION
- hides event related sub menus when no event is selected
- adds divider between sub menus and the events menu

fixes #293

![screenshot_2017-07-11-19-59-06](https://user-images.githubusercontent.com/13533840/28074889-7020c254-6677-11e7-9325-798c068a3bda.png)

![screenshot_2017-07-11-19-58-50](https://user-images.githubusercontent.com/13533840/28074928-89e1de44-6677-11e7-81d0-e9248c636a42.png)

