### PR TITLE
fix: event bus behaviour

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/data/Bus.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/Bus.java
@@ -6,10 +6,10 @@ import org.fossasia.openevent.app.common.data.models.Event;
 import javax.inject.Inject;
 
 import io.reactivex.Observable;
-import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.PublishSubject;
 
 public class Bus implements IBus {
-    private static BehaviorSubject<Event> eventIdPublisher = BehaviorSubject.create();
+    private static PublishSubject<Event> eventIdPublisher = PublishSubject.create();
 
     @Inject
     public Bus() {}


### PR DESCRIPTION
- used `PublishSubject` instead of `BehaviourSubject` in bus

fixes #368 