### PR TITLE
fix: retain main activity state on rotation

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/data/Bus.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/Bus.java
@@ -6,10 +6,10 @@ import org.fossasia.openevent.app.common.data.models.Event;
 import javax.inject.Inject;
 
 import io.reactivex.Observable;
-import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.PublishSubject;
 
 public class Bus implements IBus {
-    private static BehaviorSubject<Event> eventIdPublisher = BehaviorSubject.create();
+    private static PublishSubject<Event> eventIdPublisher = PublishSubject.create();
 
     @Inject
     public Bus() {}

--- a/app/src/main/java/org/fossasia/openevent/app/module/main/MainPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/main/MainPresenter.java
@@ -43,25 +43,23 @@ public class MainPresenter extends BasePresenter<IMainView> implements IMainPres
 
     @Override
     public void start() {
-        getView().loadInitialPage(storedEventId);
-
         if (storedEventId != -1) {
             eventRepository
                 .getEvent(storedEventId, false)
                 .compose(dispose(getDisposable()))
-                .compose(erroneous(getView()))
-                .subscribe(bus::pushSelectedEvent, Logger::logError);
+                .compose(erroneousResult(getView()))
+                .subscribe();
         }
 
         bus.getSelectedEvent()
             .compose(dispose(getDisposable()))
-            .compose(erroneousResult(getView()))
+            .compose(erroneous(getView()))
             .subscribe(event -> {
                 sharedPreferenceModel.setLong(EVENT_KEY, event.getId());
                 ContextManager.setCurrency(
                     CurrencyUtils.getCurrencySymbol(event.getPaymentCurrency())
                 );
-                getView().loadInitialPage(event.getId());
+                getView().loadInitialPage(event.getId(), true);
             }, Logger::logError);
     }
 

--- a/app/src/main/java/org/fossasia/openevent/app/module/main/contract/IMainView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/main/contract/IMainView.java
@@ -6,7 +6,7 @@ import org.fossasia.openevent.app.common.data.models.Event;
 
 public interface IMainView extends Erroneous, ItemResult<Event> {
 
-    void loadInitialPage(long eventId);
+    void loadInitialPage(long eventId, boolean reset);
 
     void onLogout();
 


### PR DESCRIPTION
- used publish subject instead of behavior subject for bus
- shifted initial page load logic on main activity start to main activity's onCreate
- bus is not used to show header title any more

fixes #375