### PR TITLE
fix: Make QR Scan Activity Translucent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
             android:exported="false"/>
         <activity
             android:name=".module.auth.AuthActivity"
-            android:theme="@style/AppTheme.NoActionBar.Translucent"
+            android:theme="@style/AppTheme.Main.Light"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -29,14 +29,14 @@
         </activity>
         <activity
             android:name=".module.attendee.qrscan.ScanQRActivity"
-            android:theme="@style/AppTheme.NoActionBar.Translucent" />
+            android:theme="@style/AppTheme.Main" />
         <activity
             android:name=".module.main.MainActivity"
             android:label="@string/title_activity_main"
-            android:theme="@style/AppTheme.NoActionBar.Translucent"/>
+            android:theme="@style/AppTheme.Main.Light"/>
         <activity
             android:name=".module.event.chart.ChartActivity"
-            android:theme="@style/AppTheme.NoActionBar.Translucent"/>
+            android:theme="@style/AppTheme.Main.Light"/>
     </application>
 
 </manifest>

--- a/app/src/main/res/values-v19/styles.xml
+++ b/app/src/main/res/values-v19/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTheme.NoActionBar.Translucent" parent="AppTheme.NoActionBar">
+    <style name="AppTheme.Main" parent="AppTheme.NoActionBar">
         <item name="android:windowTranslucentStatus">true</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTheme.NoActionBar.Translucent" parent="AppTheme.NoActionBar">
+    <style name="AppTheme.Main.Light" parent="AppTheme.Main">
+        <item name="android:windowTranslucentStatus">false</item>
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,7 +13,11 @@
         <item name="windowActionBar">false</item>
     </style>
 
-    <style name="AppTheme.NoActionBar.Translucent" parent="AppTheme.NoActionBar">
+    <style name="AppTheme.Main" parent="AppTheme.NoActionBar">
+        <!-- Defined in v19/styles.xml -->
+    </style>
+
+    <style name="AppTheme.Main.Light" parent="AppTheme.NoActionBar">
         <!-- Defined in v21/styles.xml -->
     </style>
 


### PR DESCRIPTION
- Fine tune styles
- Move v21 style (Lollipop) to v19 (Kitkat)
- Use different Main Style for QR Scan Activity

Fixes #427