### PR TITLE
fix: modify check style

### DIFF
--- a/app/config/checkstyle.xml
+++ b/app/config/checkstyle.xml
@@ -12,7 +12,9 @@ Severity: HARD
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sourceforge.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile" />
+    <module name="NewlineAtEndOfFile">
+        <property name="severity" value="ignore" />
+    </module>
 
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sourceforge.net/config_misc.html#Translation -->


### PR DESCRIPTION
- `NewlineAtEndOfFile` is disabled in check style config

fixes #488

(the commit is made from windows)