### PR TITLE
fix: App crashes when value in quantity textview is erased (#624)

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/app/binding/BindingAdapters.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/app/binding/BindingAdapters.java
@@ -20,6 +20,7 @@ import android.widget.ImageView;
 import com.mikhaellopez.circularprogressbar.CircularProgressBar;
 
 import org.fossasia.openevent.app.R;
+import org.fossasia.openevent.app.common.utils.core.Utils;
 import org.fossasia.openevent.app.common.utils.ui.ViewUtils;
 
 @SuppressWarnings("PMD.AvoidCatchingGenericException")
@@ -46,8 +47,9 @@ public final class BindingAdapters {
         return value == null ? "" : String.valueOf(value);
     }
 
+    @SuppressWarnings("PMD")
     public static Long strToLong(String value) {
-        return value == null ?  null : Long.parseLong(value);
+        return Utils.isEmpty(value) ?  null : Long.parseLong(value);
     }
 
     public static Float strToFloat(String value) {


### PR DESCRIPTION
Fixes #624

Changes: makes the default quantity zero if the quantity field in create new ticket form is left blank 
which prevents the app from crashing when the value is erased.
