### PR TITLE
fix: App crash in Ticket Create Layout (#627)

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/app/binding/BindingAdapters.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/app/binding/BindingAdapters.java
@@ -52,12 +52,14 @@ public final class BindingAdapters {
         return Utils.isEmpty(value) ?  null : Long.parseLong(value);
     }
 
+    @SuppressWarnings("PMD")
     public static Float strToFloat(String value) {
-        return value == null ?  null : Float.parseFloat(value);
+        return Utils.isEmpty(value) ? null : Float.parseFloat(value);
     }
 
+    @SuppressWarnings("PMD")
     public static Double strToDouble(String value) {
-        return value == null ? null : Double.parseDouble(value);
+        return Utils.isEmpty(value) ? null : Double.parseDouble(value);
     }
 
     @InverseMethod("getType")


### PR DESCRIPTION
Fixes #627

Changes: Use Utils.isEmpty() instead of directly using == operator to prevent the application from crashing when the value in price text view is erased. 
 
