### PR TITLE
fix: empty checks added in price and quantity editTexts

### DIFF
--- a/app/src/main/res/layout/ticket_create_form.xml
+++ b/app/src/main/res/layout/ticket_create_form.xml
@@ -109,7 +109,8 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/quantity"
                     android:text="@={ BindingAdapters.longToStr(ticket.quantity) }"
-                    android:inputType="number"/>
+                    android:inputType="number"
+                    app:validateEmpty="@{true}" />
 
             </android.support.design.widget.TextInputLayout>
         </LinearLayout>
@@ -138,7 +139,8 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/price"
                     android:text="@={ BindingAdapters.floatToStr(ticket.price) }"
-                    android:inputType="numberDecimal" />
+                    android:inputType="numberDecimal"
+                    app:validateEmpty="@{true}" />
 
             </android.support.design.widget.TextInputLayout>
         </LinearLayout>


### PR DESCRIPTION
Fixes #640 

Changes:  empty checks added in price and quantity editTexts

Screenshots for the change: 
![screenshot_20180214-171136](https://user-images.githubusercontent.com/20878145/36202563-436a07a0-11aa-11e8-8125-f20215136ded.png)
