### PR TITLE
fix: Allign ticket's default sale end time with frontend

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/utils/core/DateUtils.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/utils/core/DateUtils.java
@@ -96,4 +96,9 @@ public final class DateUtils {
         return formatDateWithDefault(format, isoString, INVALID_DATE);
     }
 
+    @NonNull
+    public static LocalDateTime getIsoOffsetTimeFromTimestamp(@NonNull String timestamp) {
+        return LocalDateTime.parse(timestamp, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
 }

--- a/app/src/main/java/org/fossasia/openevent/app/module/ticket/create/CreateTicketPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/ticket/create/CreateTicketPresenter.java
@@ -26,10 +26,17 @@ public class CreateTicketPresenter extends BasePresenter<ICreateTicketView> impl
     public CreateTicketPresenter(ITicketRepository ticketRepository) {
         this.ticketRepository = ticketRepository;
         LocalDateTime current = LocalDateTime.now();
+        String startDate = DateUtils.formatDateToIso(current);
+        ticket.getSalesStartsAt().set(startDate);
 
-        String isoDate = DateUtils.formatDateToIso(current);
-        ticket.getSalesStartsAt().set(isoDate);
-        ticket.getSalesEndsAt().set(isoDate);
+        LocalDateTime salesEndTime = current.plusDays(10);
+        LocalDateTime eventEndTime = DateUtils.getIsoOffsetTimeFromTimestamp(ContextManager.getSelectedEvent().getEndsAt().get());
+        //if less than 10 days are available in the event.
+        if (salesEndTime.isAfter(eventEndTime)) {
+            salesEndTime = eventEndTime;
+        }
+        String endDate = DateUtils.formatDateToIso(salesEndTime);
+        ticket.getSalesEndsAt().set(endDate);
         ticket.setType("free");
     }
 

--- a/app/src/test/java/org/fossasia/openevent/app/robo/ui/FragmentInstanceTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/robo/ui/FragmentInstanceTest.java
@@ -2,7 +2,10 @@ package org.fossasia.openevent.app.robo.ui;
 
 import android.support.v4.app.Fragment;
 
+import org.fossasia.openevent.app.common.app.ContextManager;
 import org.fossasia.openevent.app.common.data.UtilModel;
+import org.fossasia.openevent.app.common.data.models.Event;
+import org.fossasia.openevent.app.common.data.models.dto.ObservableString;
 import org.fossasia.openevent.app.module.attendee.list.AttendeesFragment;
 import org.fossasia.openevent.app.module.auth.forgot.password.token.request.ForgotPasswordFragment;
 import org.fossasia.openevent.app.module.auth.forgot.password.token.submit.ResetPasswordByTokenFragment;
@@ -32,6 +35,16 @@ public class FragmentInstanceTest<T extends Fragment> extends BaseParameterTest 
     public FragmentInstanceTest(Class<T> testFragmentClass, long id) {
         this.testFragmentClass = testFragmentClass;
         this.id = id;
+        if (testFragmentClass == CreateTicketFragment.class) {
+            setUpMockEvent();
+        }
+    }
+
+    private void setUpMockEvent() {
+        Event event = new Event();
+        event.timezone = "UTC";
+        event.endsAt = new ObservableString("2018-12-14T23:59:59.123456+00:00");
+        ContextManager.setSelectedEvent(event);
     }
 
     @BeforeClass
@@ -42,6 +55,7 @@ public class FragmentInstanceTest<T extends Fragment> extends BaseParameterTest 
     @AfterClass
     public static void tearDown() {
         UtilModel.releaseNetwork();
+        ContextManager.setSelectedEvent(null);
     }
 
     @ParameterizedRobolectricTestRunner.Parameters(name = "InstantiateFragment = {0}")

--- a/app/src/test/java/org/fossasia/openevent/app/unit/presenter/TicketCreatePresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/unit/presenter/TicketCreatePresenterTest.java
@@ -1,6 +1,9 @@
 package org.fossasia.openevent.app.unit.presenter;
 
+import org.fossasia.openevent.app.common.app.ContextManager;
+import org.fossasia.openevent.app.common.data.models.Event;
 import org.fossasia.openevent.app.common.data.models.Ticket;
+import org.fossasia.openevent.app.common.data.models.dto.ObservableString;
 import org.fossasia.openevent.app.common.data.repository.contract.ITicketRepository;
 import org.fossasia.openevent.app.common.utils.core.DateUtils;
 import org.fossasia.openevent.app.module.ticket.create.CreateTicketPresenter;
@@ -32,6 +35,7 @@ public class TicketCreatePresenterTest {
     @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
     @Mock private ICreateTicketView ticketsView;
     @Mock private ITicketRepository ticketRepository;
+    @Mock private Event event;
 
     private CreateTicketPresenter createTicketPresenter;
 
@@ -40,8 +44,16 @@ public class TicketCreatePresenterTest {
         RxJavaPlugins.setIoSchedulerHandler(scheduler -> Schedulers.trampoline());
         RxAndroidPlugins.setInitMainThreadSchedulerHandler(schedulerCallable -> Schedulers.trampoline());
 
+        setupMockEvent();
+        ContextManager.setSelectedEvent(event);
         createTicketPresenter = new CreateTicketPresenter(ticketRepository);
         createTicketPresenter.attach(ticketsView);
+        ContextManager.setSelectedEvent(null);
+    }
+
+    private void setupMockEvent() {
+        when(event.getTimezone()).thenReturn("UTC");
+        when(event.getEndsAt()).thenReturn(new ObservableString("2018-12-14T23:59:59.123456+00:00"));
     }
 
     @After


### PR DESCRIPTION
Fixes #614 

Changes: Alligned the ticket's default sale end time with the front end.
The front end adds 10 days to the current date for the default end time. If the number of days left for the event is less than 10 days then it is set to the end date of the event.

Screenshots for the change: 
![videotogif_2018 02 18_21 32 29](https://user-images.githubusercontent.com/21277837/36354109-44adaf10-14f5-11e8-8bc3-8dceb88372e9.gif)


@iamareebjamal Please review.

