### PR TITLE
feat: Show order details with other ticket details (#653)

### DIFF
--- a/app/src/main/res/layout/ticket_detail_layout.xml
+++ b/app/src/main/res/layout/ticket_detail_layout.xml
@@ -99,11 +99,17 @@
                     android:layout_height="wrap_content"
                     android:gravity="center_vertical"
                     android:padding="@dimen/spacing_extra_small"
-                    android:drawableLeft="@{ @drawable/ic_clock }"
-                    android:drawableStart="@{ @drawable/ic_clock }"
                     android:drawablePadding="@dimen/spacing_small"
-                    android:text='@{ ticket.salesEndsAt != null ? DateUtils.formatDateWithDefault(DateUtils.FORMAT_DAY_COMPLETE, ticket.salesEndsAt) : "" }'
-                    android:textAllCaps="true"
+                    android:text='@{ @string/maxOrder + ": " + String.valueOf(ticket.maxOrder) }'
+                    tools:text="free" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:padding="@dimen/spacing_extra_small"
+                    android:drawablePadding="@dimen/spacing_small"
+                    android:text='@{ @string/minOrder + ": " + String.valueOf(ticket.maxOrder) }'
                     tools:text="free" />
             </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,8 @@
     <string name="sale_start_time">Sale start time</string>
     <string name="sale_end_time">Sale end time</string>
     <string name="pick">Pick :</string>
+    <string name="minOrder">Minimum Order</string>
+    <string name="maxOrder">Maximum Order</string>
     <string name="about">About</string>
     <string name="title_activity_about_event">AboutEventActivity</string>
     <string name="details">Details</string>


### PR DESCRIPTION
Fixes #653 

Changes: Minumum and maximum order details are made visible to the user

Screenshots for the change: 
![screenshot_1519521379](https://user-images.githubusercontent.com/25455546/36637012-64d8298e-19f8-11e8-8222-e431e4ef8ce2.png)


