### PR TITLE
feat: Allow user to fill minOrder maxOrder details (#655)

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/app/binding/BindingAdapters.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/app/binding/BindingAdapters.java
@@ -47,6 +47,12 @@ public final class BindingAdapters {
         return value == null ? "" : String.valueOf(value);
     }
 
+    @BindingConversion
+    @InverseMethod("strToInteger")
+    public static String integerToStr(Integer value) {
+        return value == null ?  "" : String.valueOf(value);
+    }
+
     @SuppressWarnings("PMD")
     public static Long strToLong(String value) {
         return Utils.isEmpty(value) ?  null : Long.parseLong(value);
@@ -60,6 +66,11 @@ public final class BindingAdapters {
     @SuppressWarnings("PMD")
     public static Double strToDouble(String value) {
         return Utils.isEmpty(value) ? null : Double.parseDouble(value);
+    }
+
+    @SuppressWarnings("PMD.NullAssignment")
+    public static Integer strToInteger(String value) {
+        return Utils.isEmpty(value) ? null : Integer.parseInt(value);
     }
 
     @InverseMethod("getType")

--- a/app/src/main/res/layout/ticket_create_form.xml
+++ b/app/src/main/res/layout/ticket_create_form.xml
@@ -255,5 +255,30 @@
 
             </android.support.design.widget.TextInputLayout>
         </LinearLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <EditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"
+                android:hint="@string/minOrder"
+                android:text="@={ BindingAdapters.integerToStr(ticket.minOrder) }" />
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <EditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"
+                android:hint="@string/maxOrder"
+                android:text="@={ BindingAdapters.integerToStr(ticket.maxOrder) }" />
+        </android.support.design.widget.TextInputLayout>
+
     </LinearLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,8 @@
     <string name="sale_start_time">Sale start time</string>
     <string name="sale_end_time">Sale end time</string>
     <string name="pick">Pick :</string>
+    <string name="minOrder">Minimum Order</string>
+    <string name="maxOrder">Maximum Order</string>
     <string name="about">About</string>
     <string name="title_activity_about_event">AboutEventActivity</string>
     <string name="details">Details</string>


### PR DESCRIPTION
Fixes #655 

Changes: The user can now add the maximum and minimum values of 
Screenshots for the change: 
![screenshot_1519470289](https://user-images.githubusercontent.com/25455546/36629766-c6268668-1980-11e8-9e16-9dd2019e6513.png)


