### PR TITLE
feat: Added FAQ List for an Event

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/app/di/component/AppComponent.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/app/di/component/AppComponent.java
@@ -16,6 +16,7 @@ import org.fossasia.openevent.app.module.event.chart.ChartActivity;
 import org.fossasia.openevent.app.module.event.create.CreateEventFragment;
 import org.fossasia.openevent.app.module.event.dashboard.EventDashboardFragment;
 import org.fossasia.openevent.app.module.event.list.EventListFragment;
+import org.fossasia.openevent.app.module.faq.list.FaqListFragment;
 import org.fossasia.openevent.app.module.main.MainActivity;
 import org.fossasia.openevent.app.module.organizer.detail.OrganizerDetailFragment;
 import org.fossasia.openevent.app.module.organizer.password.ChangePasswordFragment;
@@ -76,4 +77,6 @@ public interface AppComponent {
     void inject(ChangePasswordFragment changePasswordFragment);
 
     void inject(CreateEventFragment createEventFragment);
+
+    void inject(FaqListFragment faqListFragment);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/DataModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/DataModule.java
@@ -1,7 +1,7 @@
 package org.fossasia.openevent.app.common.app.di.module;
 
-import org.fossasia.openevent.app.common.data.Bus;
 import org.fossasia.openevent.app.common.data.AuthModel;
+import org.fossasia.openevent.app.common.data.Bus;
 import org.fossasia.openevent.app.common.data.SharedPreferenceModel;
 import org.fossasia.openevent.app.common.data.UtilModel;
 import org.fossasia.openevent.app.common.data.contract.IAuthModel;
@@ -10,9 +10,11 @@ import org.fossasia.openevent.app.common.data.contract.ISharedPreferenceModel;
 import org.fossasia.openevent.app.common.data.contract.IUtilModel;
 import org.fossasia.openevent.app.common.data.repository.AttendeeRepository;
 import org.fossasia.openevent.app.common.data.repository.EventRepository;
+import org.fossasia.openevent.app.common.data.repository.FaqRepository;
 import org.fossasia.openevent.app.common.data.repository.TicketRepository;
 import org.fossasia.openevent.app.common.data.repository.contract.IAttendeeRepository;
 import org.fossasia.openevent.app.common.data.repository.contract.IEventRepository;
+import org.fossasia.openevent.app.common.data.repository.contract.IFAQRepository;
 import org.fossasia.openevent.app.common.data.repository.contract.ITicketRepository;
 
 import javax.inject.Singleton;
@@ -50,4 +52,8 @@ public abstract class DataModule {
     @Binds
     @Singleton
     abstract ITicketRepository bindsTicketRepository(TicketRepository ticketRepository);
+
+    @Binds
+    @Singleton
+    abstract IFAQRepository bindsFAQRepository(FaqRepository faqRepository);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/NetworkModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/NetworkModule.java
@@ -12,6 +12,7 @@ import org.fossasia.openevent.app.common.data.contract.IUtilModel;
 import org.fossasia.openevent.app.common.data.models.Attendee;
 import org.fossasia.openevent.app.common.data.models.Event;
 import org.fossasia.openevent.app.common.data.models.EventStatistics;
+import org.fossasia.openevent.app.common.data.models.Faq;
 import org.fossasia.openevent.app.common.data.models.Ticket;
 import org.fossasia.openevent.app.common.data.models.User;
 import org.fossasia.openevent.app.common.data.network.EventService;
@@ -48,7 +49,7 @@ public class NetworkModule {
 
     @Provides
     Class[] providesMappedClasses() {
-        return new Class[]{Event.class, Attendee.class, Ticket.class, User.class, EventStatistics.class};
+        return new Class[]{Event.class, Attendee.class, Ticket.class, User.class, EventStatistics.class, Faq.class};
     }
 
     @Provides

--- a/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/PresenterModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/PresenterModule.java
@@ -22,6 +22,8 @@ import org.fossasia.openevent.app.module.event.create.CreateEventPresenter;
 import org.fossasia.openevent.app.module.event.create.contract.ICreateEventPresenter;
 import org.fossasia.openevent.app.module.event.dashboard.EventDashboardPresenter;
 import org.fossasia.openevent.app.module.event.dashboard.contract.IEventDashboardPresenter;
+import org.fossasia.openevent.app.module.faq.list.FaqListPresenter;
+import org.fossasia.openevent.app.module.faq.list.contract.IFaqListPresenter;
 import org.fossasia.openevent.app.module.event.list.EventsPresenter;
 import org.fossasia.openevent.app.module.event.list.contract.IEventsPresenter;
 import org.fossasia.openevent.app.module.main.MainPresenter;
@@ -97,5 +99,8 @@ public abstract class PresenterModule {
 
     @Binds
     abstract ICreateEventPresenter bindsCreateEventPresenter(CreateEventPresenter createEventPresenter);
+
+    @Binds
+    abstract IFaqListPresenter bindsFaqListPresenter(FaqListPresenter faqListPresenter);
 
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/models/Event.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/models/Event.java
@@ -45,7 +45,7 @@ public class Event implements Comparable<Event>, IHeaderProvider {
     public static final String STATE_DRAFT = "draft";
     public static final String STATE_PUBLISHED = "published";
 
-    @Delegate(types = IEventDelegate.class, excludes = Excluding.class)
+    @Delegate(types = IEventDelegate.class, excludes = {Excluding.class})
     private final EventDelegate eventDelegate = new EventDelegate(this);
 
     @Delegate(types = EventAnalyticsDelegate.class)
@@ -122,6 +122,10 @@ public class Event implements Comparable<Event>, IHeaderProvider {
     @Relationship("tickets")
     public List<Ticket> tickets;
 
+    @ColumnIgnore
+    @Relationship("faqs")
+    public List<Faq> faqs;
+
     public Event() { }
 
 
@@ -132,7 +136,16 @@ public class Event implements Comparable<Event>, IHeaderProvider {
         return eventDelegate.getEventTickets();
     }
 
+    @JsonIgnore
+    @OneToMany(methods = {OneToMany.Method.SAVE}, variableName = "faqs")
+    List<Faq> getEventFaqs() {
+        return eventDelegate.getEventFaqs();
+    }
+
     private interface Excluding {
         List<Ticket> getEventTickets();
+
+        List<Faq> getEventFaqs();
     }
+
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/models/Faq.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/models/Faq.java
@@ -1,0 +1,44 @@
+package org.fossasia.openevent.app.common.data.models;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.jasminb.jsonapi.LongIdHandler;
+import com.github.jasminb.jsonapi.annotations.Id;
+import com.github.jasminb.jsonapi.annotations.Relationship;
+import com.github.jasminb.jsonapi.annotations.Type;
+import com.raizlabs.android.dbflow.annotation.ForeignKey;
+import com.raizlabs.android.dbflow.annotation.ForeignKeyAction;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
+
+import org.fossasia.openevent.app.common.data.db.configuration.OrgaDatabase;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@Builder
+@Type("faq")
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString(exclude = "event")
+@JsonNaming(PropertyNamingStrategy.KebabCaseStrategy.class)
+@Table(database = OrgaDatabase.class, allFields = true)
+@EqualsAndHashCode()
+public class Faq {
+
+    @Id(LongIdHandler.class)
+    @PrimaryKey
+    public Long id;
+
+    @Relationship("event")
+    @ForeignKey(stubbedRelationship = true, onDelete = ForeignKeyAction.CASCADE)
+    public Event event;
+
+    public String question;
+    public String answer;
+}

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/models/delegates/EventDelegate.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/models/delegates/EventDelegate.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 
 import org.fossasia.openevent.app.common.data.models.Event;
+import org.fossasia.openevent.app.common.data.models.Faq;
+import org.fossasia.openevent.app.common.data.models.Faq_Table;
 import org.fossasia.openevent.app.common.data.models.Ticket;
 import org.fossasia.openevent.app.common.data.models.Ticket_Table;
 import org.fossasia.openevent.app.common.data.models.delegates.contract.IEventDelegate;
@@ -63,6 +65,26 @@ public class EventDelegate implements IEventDelegate {
             .queryList());
 
         return tickets;
+    }
+
+    @Override
+    @JsonIgnore
+    public List<Faq> getEventFaqs() {
+        List<Faq> faqs = event.getFaqs();
+        if (faqs != null && !faqs.isEmpty()) {
+            for (Faq faq : faqs)
+                faq.setEvent(event);
+
+            return faqs;
+        }
+
+        event.setFaqs(
+            SQLite.select()
+                .from(Faq.class)
+                .where(Faq_Table.event_id.eq(event.getId()))
+                .queryList());
+
+        return faqs;
     }
 
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/models/delegates/contract/IEventDelegate.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/models/delegates/contract/IEventDelegate.java
@@ -1,6 +1,7 @@
 package org.fossasia.openevent.app.common.data.models.delegates.contract;
 
 import org.fossasia.openevent.app.common.data.models.Event;
+import org.fossasia.openevent.app.common.data.models.Faq;
 import org.fossasia.openevent.app.common.data.models.Ticket;
 import org.fossasia.openevent.app.common.data.models.contract.IHeaderProvider;
 
@@ -9,5 +10,7 @@ import java.util.List;
 public interface IEventDelegate extends Comparable<Event>, IHeaderProvider {
 
     List<Ticket> getEventTickets();
+
+    List<Faq> getEventFaqs();
 
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/network/EventService.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/network/EventService.java
@@ -5,6 +5,7 @@ import org.fossasia.openevent.app.common.data.models.ChangePassword;
 import org.fossasia.openevent.app.common.data.models.ChangePasswordResponse;
 import org.fossasia.openevent.app.common.data.models.Event;
 import org.fossasia.openevent.app.common.data.models.EventStatistics;
+import org.fossasia.openevent.app.common.data.models.Faq;
 import org.fossasia.openevent.app.common.data.models.RequestToken;
 import org.fossasia.openevent.app.common.data.models.RequestTokenResponse;
 import org.fossasia.openevent.app.common.data.models.SubmitToken;
@@ -82,4 +83,7 @@ public interface EventService {
 
     @GET("events/{id}/general-statistics")
     Observable<EventStatistics> getEventStatistics(@Path("id") long id);
+
+    @GET("/v1/events/{id}/faqs?include=event&fields[event]=id&page[size]=0")
+    Observable<List<Faq>> getFaqs(@Path("id") long id);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/network/EventService.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/network/EventService.java
@@ -84,6 +84,6 @@ public interface EventService {
     @GET("events/{id}/general-statistics")
     Observable<EventStatistics> getEventStatistics(@Path("id") long id);
 
-    @GET("/v1/events/{id}/faqs?include=event&fields[event]=id&page[size]=0")
+    @GET("events/{id}/faqs?include=event&fields[event]=id&page[size]=0")
     Observable<List<Faq>> getFaqs(@Path("id") long id);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/repository/FaqRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/repository/FaqRepository.java
@@ -1,0 +1,44 @@
+package org.fossasia.openevent.app.common.data.repository;
+
+import org.fossasia.openevent.app.common.data.contract.IUtilModel;
+import org.fossasia.openevent.app.common.data.db.contract.IDatabaseRepository;
+import org.fossasia.openevent.app.common.data.models.Faq;
+import org.fossasia.openevent.app.common.data.models.Faq_Table;
+import org.fossasia.openevent.app.common.data.network.EventService;
+import org.fossasia.openevent.app.common.data.repository.contract.IFAQRepository;
+
+import javax.inject.Inject;
+
+import io.reactivex.Observable;
+import timber.log.Timber;
+
+public class FaqRepository extends Repository implements IFAQRepository {
+
+    @Inject
+    public FaqRepository(IUtilModel utilModel, IDatabaseRepository databaseRepository, EventService eventService) {
+        super(utilModel, databaseRepository, eventService);
+    }
+
+    @Override
+    public Observable<Faq> getFaqs(long eventId, boolean reload) {
+        Observable<Faq> diskObservable = Observable.defer(() ->
+            databaseRepository.getItems(Faq.class, Faq_Table.event_id.eq(eventId))
+        );
+
+        Observable<Faq> networkObservable = Observable.defer(() ->
+            eventService.getFaqs(eventId)
+                .doOnNext(faqs -> {
+                    Timber.d(faqs.toString());
+                    databaseRepository
+                    .deleteAll(Faq.class)
+                    .concatWith(databaseRepository.saveList(Faq.class, faqs))
+                    .subscribe(); })
+                .flatMapIterable(faqs -> faqs));
+
+        return new AbstractObservableBuilder<Faq>(utilModel)
+            .reload(reload)
+            .withDiskObservable(diskObservable)
+            .withNetworkObservable(networkObservable)
+            .build();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/repository/contract/IFAQRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/repository/contract/IFAQRepository.java
@@ -1,0 +1,11 @@
+package org.fossasia.openevent.app.common.data.repository.contract;
+
+import org.fossasia.openevent.app.common.data.models.Faq;
+
+import io.reactivex.Observable;
+
+public interface IFAQRepository {
+
+    Observable<Faq> getFaqs(long id, boolean reload);
+
+}

--- a/app/src/main/java/org/fossasia/openevent/app/module/faq/list/FaqListAdapter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/faq/list/FaqListAdapter.java
@@ -1,0 +1,40 @@
+package org.fossasia.openevent.app.module.faq.list;
+
+import android.databinding.DataBindingUtil;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import org.fossasia.openevent.app.R;
+import org.fossasia.openevent.app.common.data.models.Faq;
+import org.fossasia.openevent.app.module.faq.list.contract.IFaqListPresenter;
+import org.fossasia.openevent.app.module.faq.list.viewholder.FaqViewHolder;
+
+import java.util.List;
+
+public class FaqListAdapter extends RecyclerView.Adapter<FaqViewHolder> {
+
+    private final List<Faq> faqs;
+
+    public FaqListAdapter(IFaqListPresenter faqListPresenter) {
+        this.faqs = faqListPresenter.getFaqs();
+    }
+
+    @Override
+    public FaqViewHolder onCreateViewHolder(ViewGroup viewGroup, int position) {
+
+        return new FaqViewHolder(
+            DataBindingUtil.inflate(LayoutInflater.from(viewGroup.getContext()),
+                R.layout.faq_layout, viewGroup, false));
+    }
+
+    @Override
+    public void onBindViewHolder(FaqViewHolder faqViewHolder, int position) {
+        faqViewHolder.bind(faqs.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return faqs.size();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/module/faq/list/FaqListFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/faq/list/FaqListFragment.java
@@ -1,0 +1,158 @@
+package org.fossasia.openevent.app.module.faq.list;
+
+import android.content.Context;
+import android.databinding.DataBindingUtil;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.widget.DefaultItemAnimator;
+import android.support.v7.widget.DividerItemDecoration;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.fossasia.openevent.app.OrgaApplication;
+import org.fossasia.openevent.app.R;
+import org.fossasia.openevent.app.common.app.lifecycle.view.BaseFragment;
+import org.fossasia.openevent.app.common.data.contract.IUtilModel;
+import org.fossasia.openevent.app.common.data.models.Faq;
+import org.fossasia.openevent.app.common.utils.ui.ViewUtils;
+import org.fossasia.openevent.app.databinding.FaqsFragmentBinding;
+import org.fossasia.openevent.app.module.faq.list.contract.IFaqListPresenter;
+import org.fossasia.openevent.app.module.faq.list.contract.IFaqListView;
+import org.fossasia.openevent.app.module.main.MainActivity;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import dagger.Lazy;
+
+public class FaqListFragment extends BaseFragment<IFaqListPresenter> implements IFaqListView {
+
+    private Context context;
+    private long eventId;
+
+    @Inject
+    IUtilModel utilModel;
+
+    @Inject
+    Lazy<IFaqListPresenter> faqsPresenter;
+
+    private FaqListAdapter faqsAdapter;
+    private FaqsFragmentBinding binding;
+    private SwipeRefreshLayout refreshLayout;
+
+    private boolean initialized;
+
+    public FaqListFragment() {
+        OrgaApplication
+            .getAppComponent()
+            .inject(this);
+    }
+
+    public static FaqListFragment newInstance(long eventId) {
+        FaqListFragment fragment = new FaqListFragment();
+        Bundle args = new Bundle();
+        args.putLong(MainActivity.EVENT_KEY, eventId);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        context = getContext();
+        if (getArguments() != null)
+            eventId = getArguments().getLong(MainActivity.EVENT_KEY);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        binding = DataBindingUtil.inflate(inflater, R.layout.faqs_fragment, container, false);
+
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        setupRecyclerView();
+        setupRefreshListener();
+        getPresenter().attach(eventId, this);
+        getPresenter().start();
+
+        initialized = true;
+    }
+
+    @Override
+    protected int getTitle() {
+        return R.string.faq;
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        refreshLayout.setOnRefreshListener(null);
+    }
+
+    private void setupRecyclerView() {
+        if (!initialized) {
+            faqsAdapter = new FaqListAdapter(getPresenter());
+
+            RecyclerView recyclerView = binding.faqsRecyclerView;
+            recyclerView.setLayoutManager(new LinearLayoutManager(context));
+            recyclerView.setAdapter(faqsAdapter);
+            recyclerView.setItemAnimator(new DefaultItemAnimator());
+            recyclerView.addItemDecoration(new DividerItemDecoration(context, DividerItemDecoration.VERTICAL));
+        }
+    }
+
+    private void setupRefreshListener() {
+        refreshLayout = binding.swipeContainer;
+        refreshLayout.setColorSchemeColors(utilModel.getResourceColor(R.color.color_accent));
+        refreshLayout.setOnRefreshListener(() -> getPresenter().loadFaqs(true));
+    }
+
+    @Override
+    public Lazy<IFaqListPresenter> getPresenterProvider() {
+        return faqsPresenter;
+    }
+
+    @Override
+    public int getLoaderId() {
+        return R.layout.faqs_fragment;
+    }
+
+    @Override
+    public void showError(String error) {
+        ViewUtils.showSnackbar(binding.getRoot(), error);
+    }
+
+    @Override
+    public void showProgress(boolean show) {
+        ViewUtils.showView(binding.progressBar, show);
+    }
+
+    @Override
+    public void onRefreshComplete(boolean success) {
+        refreshLayout.setRefreshing(false);
+        if (success)
+            ViewUtils.showSnackbar(binding.faqsRecyclerView, R.string.refresh_complete);
+    }
+
+    @Override
+    public void showResults(List<Faq> items) {
+        faqsAdapter.notifyDataSetChanged();
+    }
+
+    @Override
+    public void showEmptyView(boolean show) {
+        ViewUtils.showView(binding.emptyView, show);
+    }
+
+}

--- a/app/src/main/java/org/fossasia/openevent/app/module/faq/list/FaqListPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/faq/list/FaqListPresenter.java
@@ -1,0 +1,58 @@
+package org.fossasia.openevent.app.module.faq.list;
+
+import org.fossasia.openevent.app.common.app.lifecycle.presenter.BaseDetailPresenter;
+import org.fossasia.openevent.app.common.app.rx.Logger;
+import org.fossasia.openevent.app.common.data.models.Faq;
+import org.fossasia.openevent.app.common.data.repository.contract.IFAQRepository;
+import org.fossasia.openevent.app.module.faq.list.contract.IFaqListPresenter;
+import org.fossasia.openevent.app.module.faq.list.contract.IFaqListView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import io.reactivex.Observable;
+
+import static org.fossasia.openevent.app.common.app.rx.ViewTransformers.dispose;
+import static org.fossasia.openevent.app.common.app.rx.ViewTransformers.emptiable;
+import static org.fossasia.openevent.app.common.app.rx.ViewTransformers.progressiveErroneousRefresh;
+
+public class FaqListPresenter extends BaseDetailPresenter<Long, IFaqListView> implements IFaqListPresenter {
+
+    private final List<Faq> faqs = new ArrayList<>();
+    private final IFAQRepository faqRepository;
+
+    @Inject
+    public FaqListPresenter(IFAQRepository faqRepository) {
+        this.faqRepository = faqRepository;
+    }
+
+    @Override
+    public void start() {
+        loadFaqs(false);
+    }
+
+    @Override
+    public void loadFaqs(boolean forceReload) {
+        getFaqSource(forceReload)
+            .compose(dispose(getDisposable()))
+            .compose(progressiveErroneousRefresh(getView(), forceReload))
+            .toList()
+            .compose(emptiable(getView(), faqs))
+            .subscribe(Logger::logSuccess, Logger::logError);
+    }
+
+    private Observable<Faq> getFaqSource(boolean forceReload) {
+        if (!forceReload && !faqs.isEmpty() && isRotated())
+            return Observable.fromIterable(faqs);
+        else {
+            return faqRepository.getFaqs(getId(), forceReload);
+        }
+    }
+
+    @Override
+    public List<Faq> getFaqs() {
+        return faqs;
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/module/faq/list/contract/IFaqListPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/faq/list/contract/IFaqListPresenter.java
@@ -1,0 +1,14 @@
+package org.fossasia.openevent.app.module.faq.list.contract;
+
+import org.fossasia.openevent.app.common.app.lifecycle.contract.presenter.IDetailPresenter;
+import org.fossasia.openevent.app.common.data.models.Faq;
+
+import java.util.List;
+
+public interface IFaqListPresenter extends IDetailPresenter<Long, IFaqListView> {
+
+    List<Faq> getFaqs();
+
+    void loadFaqs(boolean forceReload);
+
+}

--- a/app/src/main/java/org/fossasia/openevent/app/module/faq/list/contract/IFaqListView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/faq/list/contract/IFaqListView.java
@@ -1,0 +1,11 @@
+package org.fossasia.openevent.app.module.faq.list.contract;
+
+import org.fossasia.openevent.app.common.app.lifecycle.contract.view.Emptiable;
+import org.fossasia.openevent.app.common.app.lifecycle.contract.view.Erroneous;
+import org.fossasia.openevent.app.common.app.lifecycle.contract.view.Progressive;
+import org.fossasia.openevent.app.common.app.lifecycle.contract.view.Refreshable;
+import org.fossasia.openevent.app.common.data.models.Faq;
+
+public interface IFaqListView extends Progressive, Erroneous, Refreshable, Emptiable<Faq> {
+
+}

--- a/app/src/main/java/org/fossasia/openevent/app/module/faq/list/viewholder/FaqViewHolder.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/faq/list/viewholder/FaqViewHolder.java
@@ -1,0 +1,22 @@
+package org.fossasia.openevent.app.module.faq.list.viewholder;
+
+import android.support.v7.widget.RecyclerView;
+
+import org.fossasia.openevent.app.common.data.models.Faq;
+import org.fossasia.openevent.app.databinding.FaqLayoutBinding;
+
+public class FaqViewHolder extends RecyclerView.ViewHolder {
+
+    private final FaqLayoutBinding binding;
+
+    public FaqViewHolder(FaqLayoutBinding binding) {
+        super(binding.getRoot());
+        this.binding = binding;
+    }
+
+    public void bind(Faq faq) {
+        binding.setFaq(faq);
+        binding.executePendingBindings();
+    }
+
+}

--- a/app/src/main/java/org/fossasia/openevent/app/module/main/MainActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/main/MainActivity.java
@@ -28,6 +28,7 @@ import org.fossasia.openevent.app.module.auth.AuthActivity;
 import org.fossasia.openevent.app.module.event.about.AboutEventActivity;
 import org.fossasia.openevent.app.module.event.dashboard.EventDashboardFragment;
 import org.fossasia.openevent.app.module.event.list.EventListFragment;
+import org.fossasia.openevent.app.module.faq.list.FaqListFragment;
 import org.fossasia.openevent.app.module.main.contract.IMainPresenter;
 import org.fossasia.openevent.app.module.main.contract.IMainView;
 import org.fossasia.openevent.app.module.organizer.detail.OrganizerDetailActivity;
@@ -198,6 +199,9 @@ public class MainActivity extends BaseActivity<IMainPresenter> implements Naviga
                 break;
             case R.id.nav_settings:
                 fragment = SettingsFragment.newInstance();
+                break;
+            case R.id.nav_faq:
+                fragment = FaqListFragment.newInstance(eventId);
                 break;
             default:
                 fragment = EventDashboardFragment.newInstance(eventId);

--- a/app/src/main/res/drawable/ic_faq.xml
+++ b/app/src/main/res/drawable/ic_faq.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M11,18h2v-2h-2v2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM12,6c-2.21,0 -4,1.79 -4,4h2c0,-1.1 0.9,-2 2,-2s2,0.9 2,2c0,2 -3,1.75 -3,5h2c0,-2.25 3,-2.5 3,-5 0,-2.21 -1.79,-4 -4,-4z"
+        android:fillColor="#555"/>
+</vector>

--- a/app/src/main/res/layout/faq_layout.xml
+++ b/app/src/main/res/layout/faq_layout.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <import type="android.view.View" />
+
+        <import type="org.fossasia.openevent.app.common.app.ContextManager" />
+
+        <variable
+            name="faq"
+            type="org.fossasia.openevent.app.common.data.models.Faq" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:baselineAligned="false"
+        android:foreground="?selectableItemBackground"
+        android:layout_marginBottom="@dimen/spacing_small"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:gravity="center_vertical">
+
+        <LinearLayout
+            style="@style/ItemPadding"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text='@{ faq.question }'
+                android:textColor="@android:color/black"
+                android:textSize="@dimen/text_size_normal" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/spacing_small"
+                android:layout_marginStart="@dimen/spacing_small"
+                android:text='@{ faq.answer }'
+                android:textSize="@dimen/text_size_extra_small" />
+
+        </LinearLayout>
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/faq_layout.xml
+++ b/app/src/main/res/layout/faq_layout.xml
@@ -30,21 +30,47 @@
             android:layout_weight="1"
             android:orientation="vertical">
 
-            <TextView
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text='@{ faq.question }'
-                android:textColor="@android:color/black"
-                android:textSize="@dimen/text_size_normal" />
+                android:orientation="horizontal">
 
-            <TextView
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/question_initial"/>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/spacing_small"
+                    android:layout_marginStart="@dimen/spacing_small"
+                    android:text='@{ faq.question }'
+                    android:textColor="@android:color/black"
+                    android:textStyle="bold"
+                    android:textSize="@dimen/text_size_normal"/>
+
+            </LinearLayout>
+
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/spacing_small"
-                android:layout_marginStart="@dimen/spacing_small"
-                android:text='@{ faq.answer }'
-                android:textSize="@dimen/text_size_extra_small" />
+                android:orientation="horizontal">
 
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/answer_initial"/>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/spacing_small"
+                    android:layout_marginStart="@dimen/spacing_small"
+                    android:text='@{ faq.answer }'
+                    android:textSize="@dimen/text_size_small"/>
+
+            </LinearLayout>
         </LinearLayout>
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/faqs_fragment.xml
+++ b/app/src/main/res/layout/faqs_fragment.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <android.support.design.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <android.support.v4.widget.SwipeRefreshLayout
+                android:id="@+id/swipeContainer"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <android.support.v7.widget.RecyclerView
+                    android:id="@+id/faqsRecyclerView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:clipToPadding="false"
+                    tools:listitem="@layout/faq_layout" />
+
+            </android.support.v4.widget.SwipeRefreshLayout>
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/empty_view"
+            android:visibility="gone">
+
+            <include layout="@layout/empty_layout" />
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/progressBar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone">
+
+            <include layout="@layout/progressbar_layout" />
+        </FrameLayout>
+    </android.support.design.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -21,6 +21,12 @@
             android:icon="@drawable/ic_info"
             android:title="@string/about"
             android:checkable="false"/>
+
+        <item
+            android:id="@+id/nav_faq"
+            android:icon="@drawable/ic_faq"
+            android:title="@string/faq"
+            android:checkable="false"/>
     </group>
 
     <group android:id="@+id/eventsMenu" android:checkableBehavior="single">

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -25,8 +25,7 @@
         <item
             android:id="@+id/nav_faq"
             android:icon="@drawable/ic_faq"
-            android:title="@string/faq"
-            android:checkable="false"/>
+            android:title="@string/faq"/>
     </group>
 
     <group android:id="@+id/eventsMenu" android:checkableBehavior="single">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,7 @@
     <string name="sessions_confirmed">Sessions Confirmed</string>
     <string name="sessions_draft">Sessions Draft</string>
     <string name="sessions_pending">Sessions Pending</string>
+    <string name="faq">FAQ</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -161,6 +161,14 @@
     <string name="sessions_draft">Sessions Draft</string>
     <string name="sessions_pending">Sessions Pending</string>
     <string name="faq">FAQ</string>
+    <string name="pdf_url">PDF URL</string>
+    <string name="country">Country</string>
+    <string name="state">State</string>
+    <string name="city">City</string>
+    <string name="address">Address</string>
+    <string name="pdf_url_colon">PDF URL:  </string>
+    <string name="answer_initial">A:</string>
+    <string name="question_initial">Q:</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>


### PR DESCRIPTION
Fixes #667 

Changes: Loading FAQ list associated with an event through network, cache it for later use in the database, and load data selectively from network and database.

Screenshots for the change: 
![fscr1](https://user-images.githubusercontent.com/23634977/36803424-7e01c3d8-1cdd-11e8-830f-6de44dd94b38.png)

![fscr2](https://user-images.githubusercontent.com/23634977/36798948-feaea430-1cd1-11e8-87d9-193a5f210664.png)
