### PR TITLE
fix: Create Event Activity will finish after event is created

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/module/event/create/CreateEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/create/CreateEventFragment.java
@@ -173,15 +173,5 @@ public class CreateEventFragment extends BaseBottomSheetFragment<ICreateEventPre
     public void setDefaultTimeZone(int index) {
         binding.form.timezoneSpinner.setSelection(index);
     }
-
-    @Override
-    public List<String> getTimeZoneList() {
-        return Arrays.asList(getResources().getStringArray(R.array.timezones));
-    }
-
-    @Override
-    public void setDefaultTimeZone(int index) {
-        binding.form.timezoneSpinner.setSelection(index);
-    }
 }
 

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/create/CreateEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/create/CreateEventFragment.java
@@ -13,6 +13,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.Toast;
 
 import org.fossasia.openevent.app.OrgaApplication;
 import org.fossasia.openevent.app.R;
@@ -155,7 +156,22 @@ public class CreateEventFragment extends BaseBottomSheetFragment<ICreateEventPre
 
     @Override
     public void onSuccess(String message) {
-        ViewUtils.showSnackbar(binding.getRoot(), message);
+        Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void close() {
+        getActivity().finish();
+    }
+
+    @Override
+    public List<String> getTimeZoneList() {
+        return Arrays.asList(getResources().getStringArray(R.array.timezones));
+    }
+
+    @Override
+    public void setDefaultTimeZone(int index) {
+        binding.form.timezoneSpinner.setSelection(index);
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/create/CreateEventPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/create/CreateEventPresenter.java
@@ -87,6 +87,9 @@ public class CreateEventPresenter extends BasePresenter<ICreateEventView> implem
             .createEvent(event)
             .compose(dispose(getDisposable()))
             .compose(progressiveErroneous(getView()))
-            .subscribe(createdEvent -> getView().onSuccess("Event Created Successfully"), Logger::logError);
+            .subscribe(createdEvent -> {
+                getView().onSuccess("Event Created Successfully");
+                getView().close();
+            }, Logger::logError);
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/create/contract/ICreateEventView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/create/contract/ICreateEventView.java
@@ -15,6 +15,8 @@ public interface ICreateEventView extends Progressive, Erroneous, Successful {
 
     void attachCurrencyCodesList(List<String> currencyCodesList);
 
+    void close();
+  
     List<String> getTimeZoneList();
 
     void setDefaultTimeZone(int index);

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/create/contract/ICreateEventView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/create/contract/ICreateEventView.java
@@ -16,7 +16,7 @@ public interface ICreateEventView extends Progressive, Erroneous, Successful {
     void attachCurrencyCodesList(List<String> currencyCodesList);
 
     void close();
-  
+
     List<String> getTimeZoneList();
 
     void setDefaultTimeZone(int index);

--- a/app/src/test/java/org/fossasia/openevent/app/unit/presenter/CreateEventPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/unit/presenter/CreateEventPresenterTest.java
@@ -128,6 +128,5 @@ public class CreateEventPresenterTest {
 
         verify(createEventView).close();
     }
-
 }
 

--- a/app/src/test/java/org/fossasia/openevent/app/unit/presenter/CreateEventPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/unit/presenter/CreateEventPresenterTest.java
@@ -113,5 +113,21 @@ public class CreateEventPresenterTest {
         verify(createEventView).onSuccess(anyString());
     }
 
+    @Test
+    public void shouldCloseOnCreated() {
+        Event event = createEventPresenter.getEvent();
+
+        when(eventRepository.createEvent(event)).thenReturn(Observable.just(event));
+
+        String isoDateNow = DateUtils.formatDateToIso(LocalDateTime.now());
+        String isoDateThen = DateUtils.formatDateToIso(LocalDateTime.MAX);
+        event.getStartsAt().set(isoDateNow);
+        event.getEndsAt().set(isoDateThen);
+
+        createEventPresenter.createEvent();
+
+        verify(createEventView).close();
+    }
+
 }
 


### PR DESCRIPTION
Fixes #613 

Changes: Create Event Activity will finish and send an intent to the fragment that started that activity, which is EventListFragment. (However, EventListFragment's parent activity is MainActivity, thus the intent will first be passed to the MainActivity) EventListFragment will then know that creating the event was successful as its onActivityResult function will be called.

Edit: Now just shows a toast instead.

Screenshots for the change: 
In this GIF, we create an event named "lol"
![createevent](https://user-images.githubusercontent.com/7023320/36901104-cfe668e6-1e60-11e8-9d38-0697ae2e9dfc.gif)

@srv-twry @iamareebjamal Could you help me to review this?
However, EventListFragment does not automatically refresh after the event is created. I have tried calling the function `getPresenter().loadUserEvents(true)` inside onActivityResult to try to refresh the events list, but to no avail. Is there a way to refresh without the user having to swipe?
