### PR TITLE
fix: Toolbar goes behind the status bar on login screen #681

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
         <activity
             android:name=".module.auth.AuthActivity"
             android:theme="@style/AppTheme.Main.Light"
-            android:label="${appName}">
+            android:label="${appName}"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Fixes #681 

Changes: Add `windowSoftInputMode="adjustResize"` to AndroidManifest.xml

Screenshots for the change: 
![appbarvisible](https://user-images.githubusercontent.com/35009811/36951695-9453ba86-202c-11e8-916b-d61584410b72.jpg)
