### PR TITLE
fix: Save copyright in db

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/data/network/EventService.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/network/EventService.java
@@ -91,7 +91,7 @@ public interface EventService {
     @POST("event-copyrights")
     Observable<Copyright> postCopyright(@Body Copyright copyright);
 
-    @GET("events/{eventId}/event-copyright")
+    @GET("events/{eventId}/event-copyright?include=event&fields[event]=id&page[size]=0")
     Observable<Copyright> getCopyright(@Path("eventId") long eventId);
 
 }

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/about/AboutEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/about/AboutEventFragment.java
@@ -39,7 +39,6 @@ public class AboutEventFragment extends BaseFragment<IAboutEventPresenter> imple
     private SwipeRefreshLayout refreshLayout;
     private long eventId;
     private boolean creatingCopyright = true;
-    private Menu menu;
 
     @Inject
     Lazy<IAboutEventPresenter> aboutEventPresenterProvider;
@@ -108,7 +107,6 @@ public class AboutEventFragment extends BaseFragment<IAboutEventPresenter> imple
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.menu_about_event, menu);
-        this.menu = menu;
     }
 
     @Override
@@ -124,6 +122,15 @@ public class AboutEventFragment extends BaseFragment<IAboutEventPresenter> imple
                 // No implementation
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        if (!creatingCopyright) {
+            MenuItem menuItem = menu.findItem(R.id.action_create_change_copyright);
+            menuItem.setTitle(R.string.edit_copyright);
+        }
     }
 
     @Override
@@ -159,8 +166,7 @@ public class AboutEventFragment extends BaseFragment<IAboutEventPresenter> imple
     @Override
     public void changeCopyrightMenuItem() {
         creatingCopyright = false;
-        MenuItem menuItem = menu.findItem(R.id.action_create_change_copyright);
-        menuItem.setTitle(R.string.edit_copyright);
+        getActivity().invalidateOptionsMenu();
     }
 
     @Override


### PR DESCRIPTION
Fixes #703 

Changes: Save copyright in db
Use recommended onPrepareOptionsMenu to change menu items

Screenshots for the change: 
![videotogif_2018 03 05_17 55 13](https://user-images.githubusercontent.com/21277837/36974957-91207d28-209e-11e8-8eb5-311eac5e3c7d.gif)

test event4 already has a copyright hence it is displayed correctly and menu item says "Edit copyright"
Test event 5 doesn't have a copyright hence it says "Create Copyright"

@iamareebjamal Please review.