### PR TITLE
fix: Remove any one of the two progress bars #705

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/module/attendee/list/AttendeesFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/attendee/list/AttendeesFragment.java
@@ -238,7 +238,10 @@ public class AttendeesFragment extends BaseFragment<IAttendeesPresenter> impleme
     private void setupRefreshListener() {
         refreshLayout = binding.swipeContainer;
         refreshLayout.setColorSchemeColors(utilModel.getResourceColor(R.color.color_accent));
-        refreshLayout.setOnRefreshListener(() -> getPresenter().loadAttendees(true));
+        refreshLayout.setOnRefreshListener(() -> {
+            refreshLayout.setRefreshing(false);
+            getPresenter().loadAttendees(true);
+        });
     }
 
     // View Implementation
@@ -256,7 +259,6 @@ public class AttendeesFragment extends BaseFragment<IAttendeesPresenter> impleme
 
     @Override
     public void onRefreshComplete(boolean success) {
-        refreshLayout.setRefreshing(false);
         if (success)
             ViewUtils.showSnackbar(binding.rvAttendeeList, R.string.refresh_complete);
     }

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/dashboard/EventDashboardFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/dashboard/EventDashboardFragment.java
@@ -135,9 +135,10 @@ public class EventDashboardFragment extends BaseFragment<IEventDashboardPresente
         container = binding.container;
         refreshLayout = binding.swipeContainer;
         refreshLayout.setColorSchemeColors(utilModel.getResourceColor(R.color.color_accent));
-        refreshLayout.setOnRefreshListener(() ->
-            getPresenter().loadDetails(true)
-        );
+        refreshLayout.setOnRefreshListener(() -> {
+            refreshLayout.setRefreshing(false);
+            getPresenter().loadDetails(true);
+        });
     }
 
     // View implementation
@@ -149,7 +150,6 @@ public class EventDashboardFragment extends BaseFragment<IEventDashboardPresente
 
     @Override
     public void onRefreshComplete(boolean success) {
-        refreshLayout.setRefreshing(false);
         if (success)
             ViewUtils.showSnackbar(container, R.string.refresh_complete);
     }

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/list/EventListFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/list/EventListFragment.java
@@ -160,7 +160,10 @@ public class EventListFragment extends BaseFragment<IEventsPresenter> implements
     private void setupRefreshListener() {
         refreshLayout = binding.swipeContainer;
         refreshLayout.setColorSchemeColors(utilModel.getResourceColor(R.color.color_accent));
-        refreshLayout.setOnRefreshListener(() -> getPresenter().loadUserEvents(true));
+        refreshLayout.setOnRefreshListener(() -> {
+            refreshLayout.setRefreshing(false);
+            getPresenter().loadUserEvents(true);
+        });
     }
 
     @Override
@@ -170,7 +173,6 @@ public class EventListFragment extends BaseFragment<IEventsPresenter> implements
 
     @Override
     public void onRefreshComplete(boolean success) {
-        refreshLayout.setRefreshing(false);
         if (success)
             ViewUtils.showSnackbar(recyclerView, R.string.refresh_complete);
     }

--- a/app/src/main/java/org/fossasia/openevent/app/module/faq/list/FaqListFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/faq/list/FaqListFragment.java
@@ -115,7 +115,10 @@ public class FaqListFragment extends BaseFragment<IFaqListPresenter> implements 
     private void setupRefreshListener() {
         refreshLayout = binding.swipeContainer;
         refreshLayout.setColorSchemeColors(utilModel.getResourceColor(R.color.color_accent));
-        refreshLayout.setOnRefreshListener(() -> getPresenter().loadFaqs(true));
+        refreshLayout.setOnRefreshListener(() -> {
+            refreshLayout.setRefreshing(false);
+            getPresenter().loadFaqs(true);
+        });
     }
 
     @Override
@@ -140,7 +143,6 @@ public class FaqListFragment extends BaseFragment<IFaqListPresenter> implements 
 
     @Override
     public void onRefreshComplete(boolean success) {
-        refreshLayout.setRefreshing(false);
         if (success)
             ViewUtils.showSnackbar(binding.faqsRecyclerView, R.string.refresh_complete);
     }

--- a/app/src/main/java/org/fossasia/openevent/app/module/ticket/list/TicketsFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/ticket/list/TicketsFragment.java
@@ -138,7 +138,10 @@ public class TicketsFragment extends BaseFragment<ITicketsPresenter> implements 
     private void setupRefreshListener() {
         refreshLayout = binding.swipeContainer;
         refreshLayout.setColorSchemeColors(utilModel.getResourceColor(R.color.color_accent));
-        refreshLayout.setOnRefreshListener(() -> getPresenter().loadTickets(true));
+        refreshLayout.setOnRefreshListener(() -> {
+            refreshLayout.setRefreshing(false);
+            getPresenter().loadTickets(true);
+        });
     }
 
     @Override
@@ -163,7 +166,6 @@ public class TicketsFragment extends BaseFragment<ITicketsPresenter> implements 
 
     @Override
     public void onRefreshComplete(boolean success) {
-        refreshLayout.setRefreshing(false);
         if (success)
             ViewUtils.showSnackbar(binding.ticketsRecyclerView, R.string.refresh_complete);
     }


### PR DESCRIPTION
Fixes #705 

Changes: Disable the SwipeRefreshLayout's ProgressBar once refresh is activated so that only the bigger ProgressBar (center) is visible while refreshing.

Screenshots for the change: 
![refresh](https://user-images.githubusercontent.com/35009811/36985472-577f940e-20bd-11e8-97ef-9117d809f4c5.gif)