### PR TITLE
test: Create tests for Copyright module

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/data/repository/CopyrightRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/repository/CopyrightRepository.java
@@ -50,8 +50,7 @@ public class CopyrightRepository extends Repository implements ICopyrightReposit
         Observable<Copyright> networkObservable = Observable.defer(() ->
             eventService.getCopyright(eventId)
                 .doOnNext(copyright -> databaseRepository
-                    .delete(Copyright.class, Copyright_Table.event_id.eq(eventId))
-                    .concatWith(databaseRepository.save(Copyright.class, copyright))
+                    .save(Copyright.class, copyright)
                     .subscribe()));
 
         return new AbstractObservableBuilder<Copyright>(utilModel)

--- a/app/src/test/java/org/fossasia/openevent/app/unit/model/CopyrightRepositoryTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/unit/model/CopyrightRepositoryTest.java
@@ -1,0 +1,178 @@
+package org.fossasia.openevent.app.unit.model;
+
+import com.raizlabs.android.dbflow.sql.language.SQLOperator;
+
+import org.fossasia.openevent.app.common.Constants;
+import org.fossasia.openevent.app.common.data.contract.IUtilModel;
+import org.fossasia.openevent.app.common.data.db.contract.IDatabaseRepository;
+import org.fossasia.openevent.app.common.data.models.Copyright;
+import org.fossasia.openevent.app.common.data.models.Event;
+import org.fossasia.openevent.app.common.data.network.EventService;
+import org.fossasia.openevent.app.common.data.repository.CopyrightRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import io.reactivex.Completable;
+import io.reactivex.Observable;
+import io.reactivex.android.plugins.RxAndroidPlugins;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CopyrightRepositoryTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private CopyrightRepository copyrightRepository;
+    private static final Copyright COPYRIGHT = new Copyright();
+    private static final Event EVENT = new Event();
+    private static final long ID = 10L;
+
+    @Mock
+    private EventService eventService;
+    @Mock
+    private IUtilModel utilModel;
+    @Mock
+    private IDatabaseRepository databaseRepository;
+
+    static {
+        COPYRIGHT.setEvent(EVENT);
+    }
+
+    @Before
+    public void setUp() {
+        copyrightRepository = new CopyrightRepository(utilModel, databaseRepository, eventService);
+        RxJavaPlugins.setIoSchedulerHandler(scheduler -> Schedulers.trampoline());
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler(schedulerCallable -> Schedulers.trampoline());
+    }
+
+    @After
+    public void tearDown() {
+        RxJavaPlugins.reset();
+        RxAndroidPlugins.reset();
+    }
+
+    // Network down tests
+
+    @Test
+    public void shouldReturnConnectionErrorOnCreateCopyright() {
+        when(utilModel.isConnected()).thenReturn(false);
+
+        Observable<Copyright> copyrightObservable = copyrightRepository.createCopyright(COPYRIGHT);
+
+        copyrightObservable
+            .test()
+            .assertError(throwable -> throwable.getMessage().equals(Constants.NO_NETWORK));
+    }
+
+    @Test
+    public void shouldReturnConnectionErrorOnGetCopyrightWithReload() {
+        when(utilModel.isConnected()).thenReturn(false);
+
+        Observable<Copyright> copyrightObservable = copyrightRepository.getCopyright(ID, true);
+
+        copyrightObservable
+            .test()
+            .assertError(throwable -> throwable.getMessage().equals(Constants.NO_NETWORK));
+    }
+
+    @Test
+    public void shouldReturnConnectionErrorOnGetCopyrightWithNoneSaved() {
+        when(utilModel.isConnected()).thenReturn(false);
+        when(databaseRepository.getItems(eq(Copyright.class), any(SQLOperator.class))).thenReturn(Observable.empty());
+
+        Observable<Copyright> copyrightObservable = copyrightRepository.getCopyright(ID, false);
+
+        copyrightObservable
+            .test()
+            .assertError(throwable -> throwable.getMessage().equals(Constants.NO_NETWORK));
+    }
+
+
+    // Network up tests
+
+    // Create copyright tests
+
+    @Test
+    public void shouldCallCreateCopyrightService() {
+        when(utilModel.isConnected()).thenReturn(true);
+        when(eventService.postCopyright(COPYRIGHT)).thenReturn(Observable.empty());
+
+        copyrightRepository.createCopyright(COPYRIGHT).subscribe();
+
+        verify(eventService).postCopyright(COPYRIGHT);
+    }
+
+    @Test
+    public void shouldSetEventOnCreatedCopyright() {
+        Copyright created = mock(Copyright.class);
+
+        when(utilModel.isConnected()).thenReturn(true);
+        when(eventService.postCopyright(COPYRIGHT)).thenReturn(Observable.just(created));
+        when(databaseRepository.save(eq(Copyright.class), eq(created))).thenReturn(Completable.complete());
+
+        copyrightRepository.createCopyright(COPYRIGHT).subscribe();
+
+        verify(created).setEvent(EVENT);
+    }
+
+    @Test
+    public void shouldSaveCreatedCopyright() {
+        Copyright created = mock(Copyright.class);
+
+        when(utilModel.isConnected()).thenReturn(true);
+        when(eventService.postCopyright(COPYRIGHT)).thenReturn(Observable.just(created));
+        when(databaseRepository.save(eq(Copyright.class), eq(created))).thenReturn(Completable.complete());
+
+        copyrightRepository.createCopyright(COPYRIGHT).subscribe();
+
+        verify(databaseRepository).save(Copyright.class, created);
+    }
+
+    // Copyright get tests
+
+    @Test
+    public void shouldCallGetCopyrightsServiceOnReload() {
+        when(utilModel.isConnected()).thenReturn(true);
+        when(eventService.getCopyright(ID)).thenReturn(Observable.empty());
+        when(databaseRepository.getItems(eq(Copyright.class), any(SQLOperator.class))).thenReturn(Observable.empty());
+
+        copyrightRepository.getCopyright(ID, true).subscribe();
+
+        verify(eventService).getCopyright(ID);
+    }
+
+    @Test
+    public void shouldCallGetCopyrightServiceWithNoneSaved() {
+        when(utilModel.isConnected()).thenReturn(true);
+        when(eventService.getCopyright(ID)).thenReturn(Observable.empty());
+        when(databaseRepository.getItems(eq(Copyright.class), any(SQLOperator.class))).thenReturn(Observable.empty());
+
+        copyrightRepository.getCopyright(ID, false).subscribe();
+
+        verify(eventService).getCopyright(ID);
+    }
+
+    @Test
+    public void shouldSaveCopyrightOnGet() {
+        when(utilModel.isConnected()).thenReturn(true);
+        when(eventService.getCopyright(ID)).thenReturn(Observable.just(COPYRIGHT));
+        when(databaseRepository.getItems(eq(Copyright.class), any(SQLOperator.class))).thenReturn(Observable.empty());
+        when(databaseRepository.save(eq(Copyright.class), eq(COPYRIGHT))).thenReturn(Completable.complete());
+
+        copyrightRepository.getCopyright(ID, true).subscribe();
+
+        verify(databaseRepository).save(Copyright.class, COPYRIGHT);
+    }
+}

--- a/app/src/test/java/org/fossasia/openevent/app/unit/presenter/CreateCopyrightPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/unit/presenter/CreateCopyrightPresenterTest.java
@@ -1,0 +1,81 @@
+package org.fossasia.openevent.app.unit.presenter;
+
+import org.fossasia.openevent.app.common.data.models.Copyright;
+import org.fossasia.openevent.app.common.data.repository.contract.ICopyrightRepository;
+import org.fossasia.openevent.app.module.event.copyright.CreateCopyrightPresenter;
+import org.fossasia.openevent.app.module.event.copyright.contract.ICreateCopyrightView;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import io.reactivex.Observable;
+import io.reactivex.android.plugins.RxAndroidPlugins;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(JUnit4.class)
+public class CreateCopyrightPresenterTest {
+
+    @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Mock private ICreateCopyrightView createCopyrightView;
+    @Mock private ICopyrightRepository copyrightRepository;
+
+    private CreateCopyrightPresenter createCopyrightPresenter;
+
+    @Before
+    public void setUp() {
+        RxJavaPlugins.setIoSchedulerHandler(scheduler -> Schedulers.trampoline());
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler(schedulerCallable -> Schedulers.trampoline());
+
+        createCopyrightPresenter = new CreateCopyrightPresenter(copyrightRepository);
+        createCopyrightPresenter.attach(createCopyrightView);
+    }
+
+    @After
+    public void tearDown() {
+        RxJavaPlugins.reset();
+        RxAndroidPlugins.reset();
+    }
+
+    @Test
+    public void shouldShowErrorOnFailure() {
+        Copyright copyright = createCopyrightPresenter.getCopyright();
+
+        when(copyrightRepository.createCopyright(copyright)).thenReturn(Observable.error(new Throwable("Error")));
+
+        createCopyrightPresenter.createCopyright();
+
+        InOrder inOrder = Mockito.inOrder(createCopyrightView);
+
+        inOrder.verify(createCopyrightView).showProgress(true);
+        inOrder.verify(createCopyrightView).showError("Error");
+        inOrder.verify(createCopyrightView).showProgress(false);
+    }
+
+    @Test
+    public void shouldShowSuccessOnCreated() {
+        Copyright copyright = createCopyrightPresenter.getCopyright();
+
+        when(copyrightRepository.createCopyright(copyright)).thenReturn(Observable.just(copyright));
+
+        createCopyrightPresenter.createCopyright();
+
+        InOrder inOrder = Mockito.inOrder(createCopyrightView);
+
+        inOrder.verify(createCopyrightView).showProgress(true);
+        inOrder.verify(createCopyrightView).onSuccess(anyString());
+        inOrder.verify(createCopyrightView).dismiss();
+        inOrder.verify(createCopyrightView).showProgress(false);
+    }
+}


### PR DESCRIPTION
Fixes #702 
Changes: Create test for 
1. Copyright Repository
2. CopyrightCreatePresenter

Remove deletion of previous Copyright in CopyrightRepository when fetching copyright.
Screenshots for the change: NA
