### PR TITLE
fix: Update FAQ List UI automatically on FAQ Creation

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/ChangeListenerModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/ChangeListenerModule.java
@@ -3,6 +3,7 @@ package org.fossasia.openevent.app.common.app.di.module;
 import org.fossasia.openevent.app.common.data.db.DatabaseChangeListener;
 import org.fossasia.openevent.app.common.data.db.contract.IDatabaseChangeListener;
 import org.fossasia.openevent.app.common.data.models.Attendee;
+import org.fossasia.openevent.app.common.data.models.Faq;
 import org.fossasia.openevent.app.common.data.models.Ticket;
 
 import dagger.Module;
@@ -21,4 +22,8 @@ public class ChangeListenerModule {
         return new DatabaseChangeListener<>(Ticket.class);
     }
 
+    @Provides
+    IDatabaseChangeListener<Faq> providesFaqChangeListener() {
+        return new DatabaseChangeListener<>(Faq.class);
+    }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/module/faq/list/FaqListPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/faq/list/FaqListPresenter.java
@@ -1,7 +1,11 @@
 package org.fossasia.openevent.app.module.faq.list;
 
+import com.raizlabs.android.dbflow.structure.BaseModel;
+
 import org.fossasia.openevent.app.common.app.lifecycle.presenter.BaseDetailPresenter;
 import org.fossasia.openevent.app.common.app.rx.Logger;
+import org.fossasia.openevent.app.common.data.db.DatabaseChangeListener;
+import org.fossasia.openevent.app.common.data.db.contract.IDatabaseChangeListener;
 import org.fossasia.openevent.app.common.data.models.Faq;
 import org.fossasia.openevent.app.common.data.repository.contract.IFaqRepository;
 import org.fossasia.openevent.app.module.faq.list.contract.IFaqListPresenter;
@@ -13,6 +17,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import io.reactivex.Observable;
+import io.reactivex.schedulers.Schedulers;
 
 import static org.fossasia.openevent.app.common.app.rx.ViewTransformers.dispose;
 import static org.fossasia.openevent.app.common.app.rx.ViewTransformers.emptiable;
@@ -22,15 +27,24 @@ public class FaqListPresenter extends BaseDetailPresenter<Long, IFaqListView> im
 
     private final List<Faq> faqs = new ArrayList<>();
     private final IFaqRepository faqRepository;
+    private final IDatabaseChangeListener<Faq> faqChangeListener;
 
     @Inject
-    public FaqListPresenter(IFaqRepository faqRepository) {
+    public FaqListPresenter(IFaqRepository faqRepository, IDatabaseChangeListener<Faq> faqChangeListener) {
         this.faqRepository = faqRepository;
+        this.faqChangeListener = faqChangeListener;
     }
 
     @Override
     public void start() {
         loadFaqs(false);
+        listenChanges();
+    }
+
+    @Override
+    public void detach() {
+        super.detach();
+        faqChangeListener.stopListening();
     }
 
     @Override
@@ -49,6 +63,16 @@ public class FaqListPresenter extends BaseDetailPresenter<Long, IFaqListView> im
         else {
             return faqRepository.getFaqs(getId(), forceReload);
         }
+    }
+
+    private void listenChanges() {
+        faqChangeListener.startListening();
+        faqChangeListener.getNotifier()
+            .compose(dispose(getDisposable()))
+            .map(DatabaseChangeListener.ModelChange::getAction)
+            .filter(action -> action.equals(BaseModel.Action.INSERT))
+            .subscribeOn(Schedulers.io())
+            .subscribe(faqModelChange -> loadFaqs(false), Logger::logError);
     }
 
     @Override


### PR DESCRIPTION
Fixes #729 

Changes: Database Change Listener used to listen changes in FAQ Database. The UI is updated automatically as an FAQ is created.

Screenshots for the change: 
![faqgvd2](https://user-images.githubusercontent.com/23634977/37109002-cd1676e0-225e-11e8-9ad5-afd112528c9d.gif)
