### PR TITLE
Draft#715

### DIFF
--- a/app/src/main/res/drawable/ic_save.xml
+++ b/app/src/main/res/drawable/ic_save.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="16dp"
+        android:height="16dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#555"
+        android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9L5,9L5,5h10v4z"/>
+</vector>

--- a/app/src/main/res/layout/event_layout.xml
+++ b/app/src/main/res/layout/event_layout.xml
@@ -17,7 +17,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/selectableItemBackground"
+        android:background="@{ event.state.equals(`draft`) ? @color/event_state_draft : android.R.attr.selectableItemBackground }"
         android:orientation="horizontal">
 
         <FrameLayout
@@ -35,7 +35,8 @@
             android:paddingEnd="@dimen/spacing_normal"
             android:paddingRight="@dimen/spacing_normal"
             android:paddingTop="@dimen/spacing_small"
-            android:paddingBottom="@dimen/spacing_small">
+            android:paddingBottom="@dimen/spacing_small"
+            android:background="?android:attr/selectableItemBackground">
 
             <ImageView
                 android:layout_width="@dimen/image_small"
@@ -72,14 +73,12 @@
                     android:layout_weight="3"
                     android:visibility='@{ Event.STATE_DRAFT.equals(event.state) ? View.VISIBLE : View.GONE }'>
 
-                    <TextView
-                        android:layout_gravity="center_vertical"
+                    <ImageView
+                        android:layout_gravity="end|bottom"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/event_state_draft"
-                        android:textSize="@dimen/text_size_small"
-                        android:background="@drawable/rounded_rectangle"
-                        app:backgroundTint="@color/grey_400"
+                        android:contentDescription="@string/save_icon"
+                        app:srcCompat="@drawable/ic_save"
                         android:paddingLeft="@dimen/spacing_small"
                         android:paddingStart="@dimen/spacing_small"
                         android:paddingRight="@dimen/spacing_small"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -26,4 +26,5 @@
     <color name="color_shadow">#cccccc</color>
     <color name="tint_drawer_item_icon">#8C000000</color>
     <color name="color_drawer_item_text">#D9000000</color>
+    <color name="event_state_draft">#FFF9C4</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,6 +182,7 @@
     <string name="create_faq">Create FAQ</string>
     <string name="question">Question</string>
     <string name="answer">Answer</string>
+    <string name="save_icon">Save Icon</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>


### PR DESCRIPTION
Fixes #715 

Changes: 
1. Added a save icon (hex code: `#555`) instead of the draft label.
2. Background is now set as light yellow (#FFF9C4) for events in state 'draft'.

Screenshots for the change: 

![newdraft](https://user-images.githubusercontent.com/35009811/37274197-f6c562a2-2601-11e8-821e-d7189ce589b5.png)
