### PR TITLE
feat: Enable Updating Copyright

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/app/di/component/AppComponent.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/app/di/component/AppComponent.java
@@ -14,6 +14,7 @@ import org.fossasia.openevent.app.module.auth.signup.SignUpFragment;
 import org.fossasia.openevent.app.module.event.about.AboutEventFragment;
 import org.fossasia.openevent.app.module.event.chart.ChartActivity;
 import org.fossasia.openevent.app.module.event.copyright.CreateCopyrightFragment;
+import org.fossasia.openevent.app.module.event.copyright.update.UpdateCopyrightFragment;
 import org.fossasia.openevent.app.module.event.create.CreateEventFragment;
 import org.fossasia.openevent.app.module.event.dashboard.EventDashboardFragment;
 import org.fossasia.openevent.app.module.event.list.EventListFragment;
@@ -85,4 +86,6 @@ public interface AppComponent {
     void inject(CreateCopyrightFragment createCopyrightFragment);
 
     void inject(CreateFaqFragment createFaqFragment);
+
+    void inject(UpdateCopyrightFragment updateCopyrightFragment);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/ChangeListenerModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/ChangeListenerModule.java
@@ -3,6 +3,7 @@ package org.fossasia.openevent.app.common.app.di.module;
 import org.fossasia.openevent.app.common.data.db.DatabaseChangeListener;
 import org.fossasia.openevent.app.common.data.db.contract.IDatabaseChangeListener;
 import org.fossasia.openevent.app.common.data.models.Attendee;
+import org.fossasia.openevent.app.common.data.models.Copyright;
 import org.fossasia.openevent.app.common.data.models.Faq;
 import org.fossasia.openevent.app.common.data.models.Ticket;
 
@@ -25,5 +26,10 @@ public class ChangeListenerModule {
     @Provides
     IDatabaseChangeListener<Faq> providesFaqChangeListener() {
         return new DatabaseChangeListener<>(Faq.class);
+    }
+
+    @Provides
+    IDatabaseChangeListener<Copyright> providesCopyrightChangeListener() {
+        return new DatabaseChangeListener<>(Copyright.class);
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/PresenterModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/app/di/module/PresenterModule.java
@@ -20,6 +20,8 @@ import org.fossasia.openevent.app.module.event.chart.ChartPresenter;
 import org.fossasia.openevent.app.module.event.chart.contract.IChartPresenter;
 import org.fossasia.openevent.app.module.event.copyright.CreateCopyrightPresenter;
 import org.fossasia.openevent.app.module.event.copyright.contract.ICreateCopyrightPresenter;
+import org.fossasia.openevent.app.module.event.copyright.update.UpdateCopyrightPresenter;
+import org.fossasia.openevent.app.module.event.copyright.update.contract.IUpdateCopyrightPresenter;
 import org.fossasia.openevent.app.module.event.create.CreateEventPresenter;
 import org.fossasia.openevent.app.module.event.create.contract.ICreateEventPresenter;
 import org.fossasia.openevent.app.module.event.dashboard.EventDashboardPresenter;
@@ -112,4 +114,7 @@ public abstract class PresenterModule {
 
     @Binds
     abstract ICreateFaqPresenter bindsCreateFaqPresenter(CreateFaqPresenter createFaqPresenter);
+
+    @Binds
+    abstract IUpdateCopyrightPresenter bindsUpdateCopyrightPresenter(UpdateCopyrightPresenter updateCopyrightPresenter);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/network/EventService.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/network/EventService.java
@@ -94,6 +94,9 @@ public interface EventService {
     @GET("events/{eventId}/event-copyright?include=event&fields[event]=id&page[size]=0")
     Observable<Copyright> getCopyright(@Path("eventId") long eventId);
 
+    @PATCH("event-copyrights/{id}")
+    Observable<Copyright> patchCopyright(@Path("id") long id, @Body Copyright copyright);
+
     @POST("faqs")
     Observable<Faq> postFaq(@Body Faq faq);
 

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/repository/CopyrightRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/repository/CopyrightRepository.java
@@ -59,4 +59,19 @@ public class CopyrightRepository extends Repository implements ICopyrightReposit
             .withNetworkObservable(networkObservable)
             .build();
     }
+
+    @NonNull
+    @Override
+    public Observable<Copyright> updateCopyright(Copyright copyright) {
+        if (!utilModel.isConnected()) {
+            return Observable.error(new Throwable(Constants.NO_NETWORK));
+        }
+
+        return eventService.patchCopyright(copyright.getId(), copyright)
+            .doOnNext(updatedCopyright -> databaseRepository
+                .update(Copyright.class, updatedCopyright)
+                .subscribe())
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread());
+    }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/repository/contract/ICopyrightRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/repository/contract/ICopyrightRepository.java
@@ -13,4 +13,7 @@ public interface ICopyrightRepository {
 
     @NonNull
     Observable<Copyright> getCopyright(long id, boolean reload);
+
+    @NonNull
+    Observable<Copyright> updateCopyright(Copyright copyright);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/about/AboutEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/about/AboutEventFragment.java
@@ -27,6 +27,7 @@ import org.fossasia.openevent.app.databinding.AboutEventFragmentBinding;
 import org.fossasia.openevent.app.module.event.about.contract.IAboutEventPresenter;
 import org.fossasia.openevent.app.module.event.about.contract.IAboutEventVew;
 import org.fossasia.openevent.app.module.event.copyright.CreateCopyrightFragment;
+import org.fossasia.openevent.app.module.event.copyright.update.UpdateCopyrightFragment;
 
 import javax.inject.Inject;
 
@@ -115,6 +116,9 @@ public class AboutEventFragment extends BaseFragment<IAboutEventPresenter> imple
             case R.id.action_create_change_copyright:
                 if (creatingCopyright) {
                     BottomSheetDialogFragment bottomSheetDialogFragment = CreateCopyrightFragment.newInstance();
+                    bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
+                } else {
+                    BottomSheetDialogFragment bottomSheetDialogFragment = UpdateCopyrightFragment.newInstance(getPresenter().getCopyright());
                     bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
                 }
                 break;

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/about/contract/IAboutEventPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/about/contract/IAboutEventPresenter.java
@@ -1,10 +1,13 @@
 package org.fossasia.openevent.app.module.event.about.contract;
 
 import org.fossasia.openevent.app.common.app.lifecycle.contract.presenter.IDetailPresenter;
+import org.fossasia.openevent.app.common.data.models.Copyright;
 
 public interface IAboutEventPresenter extends IDetailPresenter<Long, IAboutEventVew> {
 
     void loadEvent(boolean forceReload);
 
     void loadCopyright(boolean forceReload);
+
+    Copyright getCopyright();
 }

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/copyright/update/UpdateCopyrightFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/copyright/update/UpdateCopyrightFragment.java
@@ -1,0 +1,97 @@
+package org.fossasia.openevent.app.module.event.copyright.update;
+
+import android.content.Context;
+import android.databinding.DataBindingUtil;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.fossasia.openevent.app.OrgaApplication;
+import org.fossasia.openevent.app.R;
+import org.fossasia.openevent.app.common.app.lifecycle.view.BaseBottomSheetFragment;
+import org.fossasia.openevent.app.common.data.models.Copyright;
+import org.fossasia.openevent.app.common.utils.ui.ViewUtils;
+import org.fossasia.openevent.app.databinding.CopyrightCreateLayoutBinding;
+import org.fossasia.openevent.app.module.event.copyright.update.contract.IUpdateCopyrightPresenter;
+import org.fossasia.openevent.app.module.event.copyright.update.contract.IUpdateCopyrightView;
+
+import javax.inject.Inject;
+
+import br.com.ilhasoft.support.validation.Validator;
+import dagger.Lazy;
+
+import static org.fossasia.openevent.app.common.utils.ui.ViewUtils.showView;
+
+public class UpdateCopyrightFragment extends BaseBottomSheetFragment<IUpdateCopyrightPresenter> implements IUpdateCopyrightView {
+
+    @Inject
+    Lazy<IUpdateCopyrightPresenter> presenterProvider;
+    private Validator validator;
+    private CopyrightCreateLayoutBinding binding;
+    private static Copyright copyright;
+
+    public static UpdateCopyrightFragment newInstance(Copyright copyright) {
+        UpdateCopyrightFragment.copyright = copyright;
+        return new UpdateCopyrightFragment();
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        OrgaApplication.getAppComponent()
+            .inject(this);
+
+        super.onCreate(savedInstanceState);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        final Context contextThemeWrapper = new ContextThemeWrapper(getActivity(), R.style.AppTheme);
+        LayoutInflater localInflater = inflater.cloneInContext(contextThemeWrapper);
+        binding =  DataBindingUtil.inflate(localInflater, R.layout.copyright_create_layout, container, false);
+        validator = new Validator(binding.form);
+
+        binding.submit.setOnClickListener(view -> {
+            if (validator.validate())
+                getPresenter().updateCopyright(copyright);
+        });
+
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        getPresenter().attach(this);
+        binding.setCopyright(copyright);
+    }
+
+    @Override
+    public Lazy<IUpdateCopyrightPresenter> getPresenterProvider() {
+        return presenterProvider;
+    }
+
+    @Override
+    public int getLoaderId() {
+        return R.layout.copyright_create_layout;
+    }
+
+    @Override
+    public void showProgress(boolean show) {
+        showView(binding.progressBar, show);
+    }
+
+    @Override
+    public void showError(String error) {
+        ViewUtils.showSnackbar(binding.getRoot(), error);
+    }
+
+    @Override
+    public void onSuccess(String message) {
+        ViewUtils.showSnackbar(binding.getRoot(), message);
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/copyright/update/UpdateCopyrightPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/copyright/update/UpdateCopyrightPresenter.java
@@ -1,0 +1,53 @@
+package org.fossasia.openevent.app.module.event.copyright.update;
+
+import org.fossasia.openevent.app.common.app.ContextManager;
+import org.fossasia.openevent.app.common.app.lifecycle.presenter.BasePresenter;
+import org.fossasia.openevent.app.common.app.rx.Logger;
+import org.fossasia.openevent.app.common.data.models.Copyright;
+import org.fossasia.openevent.app.common.data.repository.contract.ICopyrightRepository;
+import org.fossasia.openevent.app.common.utils.core.StringUtils;
+import org.fossasia.openevent.app.module.event.copyright.update.contract.IUpdateCopyrightPresenter;
+import org.fossasia.openevent.app.module.event.copyright.update.contract.IUpdateCopyrightView;
+
+import javax.inject.Inject;
+
+import static org.fossasia.openevent.app.common.app.rx.ViewTransformers.dispose;
+import static org.fossasia.openevent.app.common.app.rx.ViewTransformers.progressiveErroneous;
+
+public class UpdateCopyrightPresenter extends BasePresenter<IUpdateCopyrightView> implements IUpdateCopyrightPresenter {
+
+    private final ICopyrightRepository copyrightRepository;
+
+    @Inject
+    public UpdateCopyrightPresenter(ICopyrightRepository copyrightRepository) {
+        this.copyrightRepository = copyrightRepository;
+    }
+
+    @Override
+    public void start() {
+        // Nothing to do
+    }
+
+    private void nullifyEmptyFields(Copyright copyright) {
+        copyright.setHolderUrl(StringUtils.emptyToNull(copyright.getHolderUrl()));
+        copyright.setLicence(StringUtils.emptyToNull(copyright.getLicence()));
+        copyright.setLicenceUrl(StringUtils.emptyToNull(copyright.getLicenceUrl()));
+        copyright.setYear(StringUtils.emptyToNull(copyright.getYear()));
+        copyright.setLogoUrl(StringUtils.emptyToNull(copyright.getLogoUrl()));
+    }
+
+    @Override
+    public void updateCopyright(Copyright copyright) {
+        nullifyEmptyFields(copyright);
+
+        copyright.setEvent(ContextManager.getSelectedEvent());
+
+        copyrightRepository.updateCopyright(copyright)
+            .compose(dispose(getDisposable()))
+            .compose(progressiveErroneous(getView()))
+            .subscribe(updatedTicket -> {
+                getView().onSuccess("Copyright Updated");
+                getView().dismiss();
+            }, Logger::logError);
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/copyright/update/contract/IUpdateCopyrightPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/copyright/update/contract/IUpdateCopyrightPresenter.java
@@ -1,0 +1,9 @@
+package org.fossasia.openevent.app.module.event.copyright.update.contract;
+
+import org.fossasia.openevent.app.common.app.lifecycle.contract.presenter.IPresenter;
+import org.fossasia.openevent.app.common.data.models.Copyright;
+
+public interface IUpdateCopyrightPresenter extends IPresenter<IUpdateCopyrightView> {
+
+    void updateCopyright(Copyright copyright);
+}

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/copyright/update/contract/IUpdateCopyrightView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/copyright/update/contract/IUpdateCopyrightView.java
@@ -1,0 +1,10 @@
+package org.fossasia.openevent.app.module.event.copyright.update.contract;
+
+import org.fossasia.openevent.app.common.app.lifecycle.contract.view.Erroneous;
+import org.fossasia.openevent.app.common.app.lifecycle.contract.view.Progressive;
+import org.fossasia.openevent.app.common.app.lifecycle.contract.view.Successful;
+
+public interface IUpdateCopyrightView extends Progressive, Erroneous, Successful {
+
+    void dismiss();
+}


### PR DESCRIPTION
Fixes #737 

Changes: Add feature to update the Copyright of the Event.

Screenshots for the change: 
![videotogif_2018 03 23_12 17 19](https://user-images.githubusercontent.com/21277837/37816587-a55b3f4a-2e99-11e8-8cb2-abf4762b2a8c.gif)


@iamareebjamal Please review.