### PR TITLE
fix:Multiple Progress bars don't appear on refreshing

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/module/event/about/AboutEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/about/AboutEventFragment.java
@@ -99,6 +99,7 @@ public class AboutEventFragment extends BaseFragment<IAboutEventPresenter> imple
         refreshLayout = binding.swipeContainer;
         refreshLayout.setColorSchemeColors(utilModel.getResourceColor(R.color.color_accent));
         refreshLayout.setOnRefreshListener(() -> {
+            refreshLayout.setRefreshing(false);
             getPresenter().loadEvent(true);
             getPresenter().loadCopyright(true);
         });

--- a/app/src/main/java/org/fossasia/openevent/app/module/organizer/detail/OrganizerDetailFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/organizer/detail/OrganizerDetailFragment.java
@@ -102,7 +102,11 @@ public class OrganizerDetailFragment extends BaseFragment<IOrganizerDetailPresen
     private void setupRefreshListener() {
         refreshLayout = binding.swipeContainer;
         refreshLayout.setColorSchemeColors(utilModel.getResourceColor(R.color.color_accent));
-        refreshLayout.setOnRefreshListener(() -> getPresenter().loadOrganizer(true));
+
+        refreshLayout.setOnRefreshListener(() -> {
+            refreshLayout.setRefreshing(false);
+            getPresenter().loadOrganizer(true);
+        });
     }
 
     @Override


### PR DESCRIPTION
Fixes #705 
Changes: Multiple progress bars were removed from the OrganizersDetailFragment and AboutEventFragment.
