### PR TITLE
feat: Allow deleting Copyright of the Event

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/data/network/EventService.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/network/EventService.java
@@ -97,7 +97,9 @@ public interface EventService {
     @PATCH("event-copyrights/{id}")
     Observable<Copyright> patchCopyright(@Path("id") long id, @Body Copyright copyright);
 
+    @DELETE("event-copyrights/{id}")
+    Completable deleteCopyright(@Path("id") long id);
+
     @POST("faqs")
     Observable<Faq> postFaq(@Body Faq faq);
-
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/repository/CopyrightRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/repository/CopyrightRepository.java
@@ -12,6 +12,7 @@ import org.fossasia.openevent.app.common.data.repository.contract.ICopyrightRepo
 
 import javax.inject.Inject;
 
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
@@ -71,6 +72,23 @@ public class CopyrightRepository extends Repository implements ICopyrightReposit
             .doOnNext(updatedCopyright -> databaseRepository
                 .update(Copyright.class, updatedCopyright)
                 .subscribe())
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread());
+    }
+
+    @NonNull
+    @Override
+    public Completable deleteCopyright(long id) {
+        if (!utilModel.isConnected()) {
+            return Completable.error(new Throwable(Constants.NO_NETWORK));
+        }
+
+        return eventService.deleteCopyright(id)
+            .doOnComplete(() -> {
+                databaseRepository
+                    .delete(Copyright.class, Copyright_Table.id.eq(id))
+                    .subscribe();
+            })
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread());
     }

--- a/app/src/main/java/org/fossasia/openevent/app/common/data/repository/contract/ICopyrightRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/data/repository/contract/ICopyrightRepository.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 
 import org.fossasia.openevent.app.common.data.models.Copyright;
 
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 
 public interface ICopyrightRepository {
@@ -16,4 +17,7 @@ public interface ICopyrightRepository {
 
     @NonNull
     Observable<Copyright> updateCopyright(Copyright copyright);
+
+    @NonNull
+    Completable deleteCopyright(long id);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/about/AboutEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/about/AboutEventFragment.java
@@ -123,6 +123,9 @@ public class AboutEventFragment extends BaseFragment<IAboutEventPresenter> imple
                     bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
                 }
                 break;
+            case R.id.action_delete_copyright:
+                getPresenter().deleteCopyright();
+                break;
             default:
                 // No implementation
         }
@@ -132,9 +135,16 @@ public class AboutEventFragment extends BaseFragment<IAboutEventPresenter> imple
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        if (!creatingCopyright) {
+        if (creatingCopyright) {
+            MenuItem menuItem = menu.findItem(R.id.action_create_change_copyright);
+            menuItem.setTitle(R.string.create_copyright);
+            menuItem = menu.findItem(R.id.action_delete_copyright);
+            menuItem.setVisible(false);
+        } else {
             MenuItem menuItem = menu.findItem(R.id.action_create_change_copyright);
             menuItem.setTitle(R.string.edit_copyright);
+            menuItem = menu.findItem(R.id.action_delete_copyright);
+            menuItem.setVisible(true);
         }
     }
 
@@ -164,8 +174,8 @@ public class AboutEventFragment extends BaseFragment<IAboutEventPresenter> imple
     }
 
     @Override
-    public void changeCopyrightMenuItem() {
-        creatingCopyright = false;
+    public void changeCopyrightMenuItem(boolean creatingCopyright) {
+        this.creatingCopyright = creatingCopyright;
         getActivity().invalidateOptionsMenu();
     }
 
@@ -184,5 +194,10 @@ public class AboutEventFragment extends BaseFragment<IAboutEventPresenter> imple
         refreshLayout.setRefreshing(false);
         if (success)
             ViewUtils.showSnackbar(binding.mainContent, R.string.refresh_complete);
+    }
+
+    @Override
+    public void showCopyrightDeleted(String message) {
+        ViewUtils.showSnackbar(binding.mainContent, message);
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/about/contract/IAboutEventPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/about/contract/IAboutEventPresenter.java
@@ -10,4 +10,6 @@ public interface IAboutEventPresenter extends IDetailPresenter<Long, IAboutEvent
     void loadCopyright(boolean forceReload);
 
     Copyright getCopyright();
+
+    void deleteCopyright();
 }

--- a/app/src/main/java/org/fossasia/openevent/app/module/event/about/contract/IAboutEventVew.java
+++ b/app/src/main/java/org/fossasia/openevent/app/module/event/about/contract/IAboutEventVew.java
@@ -13,5 +13,7 @@ public interface IAboutEventVew extends Progressive, Erroneous, Refreshable, Ite
 
     void showCopyright(Copyright copyright);
 
-    void changeCopyrightMenuItem();
+    void changeCopyrightMenuItem(boolean creatingCopyright);
+
+    void showCopyrightDeleted(String message);
 }

--- a/app/src/main/res/menu/menu_about_event.xml
+++ b/app/src/main/res/menu/menu_about_event.xml
@@ -9,4 +9,10 @@
         android:id="@+id/action_create_change_copyright"
         android:title="@string/create_copyright"
         app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/action_delete_copyright"
+        android:title="@string/delete_copyright"
+        app:showAsAction="never"
+        android:visible="false"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,6 +190,7 @@
     <string name="save_icon">Save Icon</string>
     <string name="use_date_time_picker">Use Picker</string>
     <string name="welcome">Hi, Organiser!</string>
+    <string name="delete_copyright">Delete Copyright</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>

--- a/app/src/test/java/org/fossasia/openevent/app/unit/presenter/AboutEventPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/unit/presenter/AboutEventPresenterTest.java
@@ -110,7 +110,7 @@ public class AboutEventPresenterTest {
 
         aboutEventPresenter.loadCopyright(false);
 
-        verify(aboutEventVew).changeCopyrightMenuItem();
+        verify(aboutEventVew).changeCopyrightMenuItem(false);
     }
 
     @Test


### PR DESCRIPTION
Fixes #738 

Changes: Added an option to delete the Copyright of the Event if it exists

Screenshots for the change: 
![videotogif_2018 03 25_16 59 32](https://user-images.githubusercontent.com/21277837/37874634-3f86d7c0-3050-11e8-9693-3389e23e5ee1.gif)
