### PR TITLE
test: Update tests for the Copyright module

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
@@ -18,13 +18,13 @@ import android.view.ViewGroup;
 import org.fossasia.openevent.app.OrgaApplication;
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
-import org.fossasia.openevent.app.ui.ViewUtils;
 import org.fossasia.openevent.app.core.event.copyright.CreateCopyrightFragment;
 import org.fossasia.openevent.app.core.event.copyright.update.UpdateCopyrightFragment;
 import org.fossasia.openevent.app.data.IUtilModel;
 import org.fossasia.openevent.app.data.models.Copyright;
 import org.fossasia.openevent.app.data.models.Event;
 import org.fossasia.openevent.app.databinding.AboutEventFragmentBinding;
+import org.fossasia.openevent.app.ui.ViewUtils;
 
 import java.util.Arrays;
 
@@ -126,7 +126,7 @@ public class AboutEventFragment extends BaseFragment<AboutEventPresenter> implem
                 }
                 break;
             case R.id.action_delete_copyright:
-                getPresenter().deleteCopyright();
+                getPresenter().deleteCopyright(getPresenter().getCopyright().getId());
                 break;
             default:
                 // No implementation

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventPresenter.java
@@ -94,9 +94,9 @@ public class AboutEventPresenter extends BaseDetailPresenter<Long, IAboutEventVe
     }
 
     @SuppressWarnings("PMD.NullAssignment")
-    public void deleteCopyright() {
+    public void deleteCopyright(long id) {
         copyrightRepository
-            .deleteCopyright(copyright.getId())
+            .deleteCopyright(id)
             .compose(disposeCompletable(getDisposable()))
             .compose(progressiveErroneousCompletable(getView()))
             .subscribe(() -> {

--- a/app/src/test/java/org/fossasia/openevent/app/unit/model/CopyrightRepositoryTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/unit/model/CopyrightRepositoryTest.java
@@ -48,6 +48,7 @@ public class CopyrightRepositoryTest {
 
     static {
         COPYRIGHT.setEvent(EVENT);
+        COPYRIGHT.setId(ID);
     }
 
     @Before
@@ -99,6 +100,27 @@ public class CopyrightRepositoryTest {
             .assertError(throwable -> throwable.getMessage().equals(Constants.NO_NETWORK));
     }
 
+    @Test
+    public void shouldReturnConnectionErrorOnUpdateCopyright() {
+        when(utilModel.isConnected()).thenReturn(false);
+
+        Observable<Copyright> copyrightObservable = copyrightRepository.updateCopyright(COPYRIGHT);
+
+        copyrightObservable
+            .test()
+            .assertError(throwable -> throwable.getMessage().equals(Constants.NO_NETWORK));
+    }
+
+    @Test
+    public void shouldReturnConnectionErrorOnDeleteCopyright() {
+        when(utilModel.isConnected()).thenReturn(false);
+
+        Completable copyrightCompletable = copyrightRepository.deleteCopyright(ID);
+
+        copyrightCompletable
+            .test()
+            .assertError(throwable -> throwable.getMessage().equals(Constants.NO_NETWORK));
+    }
 
     // Network up tests
 
@@ -175,4 +197,42 @@ public class CopyrightRepositoryTest {
 
         verify(databaseRepository).save(Copyright.class, COPYRIGHT);
     }
+
+    // Copyright update tests
+
+    @Test
+    public void shouldCallUpdateCopyrightService() {
+        when(utilModel.isConnected()).thenReturn(true);
+        when(eventService.patchCopyright(ID, COPYRIGHT)).thenReturn(Observable.empty());
+
+        copyrightRepository.updateCopyright(COPYRIGHT).subscribe();
+
+        verify(eventService).patchCopyright(ID, COPYRIGHT);
+    }
+
+    @Test
+    public void shouldUpdateUpdatedCopyright() {
+        Copyright updated = mock(Copyright.class);
+
+        when(utilModel.isConnected()).thenReturn(true);
+        when(eventService.patchCopyright(ID, COPYRIGHT)).thenReturn(Observable.just(updated));
+        when(databaseRepository.update(eq(Copyright.class), eq(updated))).thenReturn(Completable.complete());
+
+        copyrightRepository.updateCopyright(COPYRIGHT).subscribe();
+
+        verify(databaseRepository).update(Copyright.class, updated);
+    }
+
+    // Copyright delete tests
+
+    @Test
+    public void shouldCallDeleteCopyrightService() {
+        when(utilModel.isConnected()).thenReturn(true);
+        when(eventService.deleteCopyright(ID)).thenReturn(Completable.complete());
+
+        copyrightRepository.deleteCopyright(ID).subscribe();
+
+        verify(eventService).deleteCopyright(ID);
+    }
+
 }

--- a/app/src/test/java/org/fossasia/openevent/app/unit/presenter/AboutEventPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/unit/presenter/AboutEventPresenterTest.java
@@ -1,12 +1,12 @@
 package org.fossasia.openevent.app.unit.presenter;
 
+import org.fossasia.openevent.app.core.event.about.AboutEventPresenter;
+import org.fossasia.openevent.app.core.event.about.IAboutEventVew;
 import org.fossasia.openevent.app.data.db.IDatabaseChangeListener;
 import org.fossasia.openevent.app.data.models.Copyright;
 import org.fossasia.openevent.app.data.models.Event;
 import org.fossasia.openevent.app.data.repository.ICopyrightRepository;
 import org.fossasia.openevent.app.data.repository.IEventRepository;
-import org.fossasia.openevent.app.core.event.about.AboutEventPresenter;
-import org.fossasia.openevent.app.core.event.about.IAboutEventVew;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,6 +19,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.android.plugins.RxAndroidPlugins;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -26,6 +27,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -168,5 +170,20 @@ public class AboutEventPresenterTest {
         aboutEventPresenter.detach();
 
         verify(copyrightChangeListener).stopListening();
+    }
+
+    @Test
+    public void shouldDeleteCopyrightSuccessfully() {
+        when(copyrightRepository.deleteCopyright(ID)).thenReturn(Completable.complete());
+        when(copyrightRepository.getCopyright(ID, true)).thenReturn(Observable.just(COPYRIGHT));
+
+        InOrder inOrder = Mockito.inOrder(copyrightRepository, aboutEventVew);
+
+        aboutEventPresenter.deleteCopyright(ID);
+
+        inOrder.verify(copyrightRepository).deleteCopyright(ID);
+        inOrder.verify(aboutEventVew).showProgress(true);
+        inOrder.verify(aboutEventVew).showCopyrightDeleted("Copyright Deleted");
+        inOrder.verify(aboutEventVew, times(2)).showProgress(false); // delete copyright operation and load copyright operation
     }
 }


### PR DESCRIPTION
Fixes #848 

Changes: Updated tests for ```AboutEventPresenterTest``` and ```CopyrightRepositoryTest```
Modified ```deleteCopyright``` method in the ```AboutEventPresenter``` to allow Unit testing.

Screenshots for the change: NA
