### PR TITLE
fix: Remove static Copyright field from UpdateCopyrightFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
@@ -116,7 +116,7 @@ public class AboutEventFragment extends BaseFragment<AboutEventPresenter> implem
                     BottomSheetDialogFragment bottomSheetDialogFragment = CreateCopyrightFragment.newInstance();
                     bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
                 } else {
-                    BottomSheetDialogFragment bottomSheetDialogFragment = UpdateCopyrightFragment.newInstance(getPresenter().getCopyright());
+                    BottomSheetDialogFragment bottomSheetDialogFragment = UpdateCopyrightFragment.newInstance(eventId);
                     bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
                 }
                 break;

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/IUpdateCopyrightView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/IUpdateCopyrightView.java
@@ -3,8 +3,11 @@ package org.fossasia.openevent.app.core.event.copyright.update;
 import org.fossasia.openevent.app.common.mvp.view.Erroneous;
 import org.fossasia.openevent.app.common.mvp.view.Progressive;
 import org.fossasia.openevent.app.common.mvp.view.Successful;
+import org.fossasia.openevent.app.data.models.Copyright;
 
 public interface IUpdateCopyrightView extends Progressive, Erroneous, Successful {
 
     void dismiss();
+
+    void setCopyright(Copyright copyright);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/UpdateCopyrightFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/UpdateCopyrightFragment.java
@@ -1,11 +1,9 @@
 package org.fossasia.openevent.app.core.event.copyright.update;
 
-import android.content.Context;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -25,28 +23,34 @@ import static org.fossasia.openevent.app.ui.ViewUtils.showView;
 
 public class UpdateCopyrightFragment extends BaseBottomSheetFragment<UpdateCopyrightPresenter> implements IUpdateCopyrightView {
 
+    private static final String EVENT_ID = "id";
+
     @Inject
     Lazy<UpdateCopyrightPresenter> presenterProvider;
     private Validator validator;
     private CopyrightCreateLayoutBinding binding;
-    private static Copyright copyright;
+    private long copyrightId;
 
-    public static UpdateCopyrightFragment newInstance(Copyright copyright) {
-        UpdateCopyrightFragment.copyright = copyright;
-        return new UpdateCopyrightFragment();
+    public static UpdateCopyrightFragment newInstance(long id) {
+        Bundle bundle = new Bundle();
+        bundle.putLong(EVENT_ID, id);
+        UpdateCopyrightFragment updateCopyrightFragment = new UpdateCopyrightFragment();
+        updateCopyrightFragment.setArguments(bundle);
+        return updateCopyrightFragment;
     }
 
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        final Context contextThemeWrapper = new ContextThemeWrapper(getActivity(), R.style.AppTheme);
-        LayoutInflater localInflater = inflater.cloneInContext(contextThemeWrapper);
-        binding =  DataBindingUtil.inflate(localInflater, R.layout.copyright_create_layout, container, false);
+        binding =  DataBindingUtil.inflate(inflater, R.layout.copyright_create_layout, container, false);
         validator = new Validator(binding.form);
+
+        Bundle bundle = getArguments();
+        copyrightId = bundle.getLong(EVENT_ID);
 
         binding.submit.setOnClickListener(view -> {
             if (validator.validate())
-                getPresenter().updateCopyright(copyright);
+                getPresenter().updateCopyright();
         });
 
         return binding.getRoot();
@@ -56,6 +60,11 @@ public class UpdateCopyrightFragment extends BaseBottomSheetFragment<UpdateCopyr
     public void onStart() {
         super.onStart();
         getPresenter().attach(this);
+        getPresenter().loadCopyright(copyrightId);
+    }
+
+    @Override
+    public void setCopyright(Copyright copyright) {
         binding.setCopyright(copyright);
     }
 

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/UpdateCopyrightPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/UpdateCopyrightPresenter.java
@@ -15,6 +15,7 @@ import static org.fossasia.openevent.app.common.rx.ViewTransformers.progressiveE
 public class UpdateCopyrightPresenter extends BasePresenter<IUpdateCopyrightView> {
 
     private final ICopyrightRepository copyrightRepository;
+    private Copyright copyright;
 
     @Inject
     public UpdateCopyrightPresenter(ICopyrightRepository copyrightRepository) {
@@ -34,7 +35,20 @@ public class UpdateCopyrightPresenter extends BasePresenter<IUpdateCopyrightView
         copyright.setLogoUrl(StringUtils.emptyToNull(copyright.getLogoUrl()));
     }
 
-    public void updateCopyright(Copyright copyright) {
+    public void loadCopyright(long eventId) {
+        copyrightRepository
+            .getCopyright(eventId, false)
+            .compose(dispose(getDisposable()))
+            .compose(progressiveErroneous(getView()))
+            .doFinally(this::showCopyright)
+            .subscribe(loadedCopyright -> this.copyright = loadedCopyright, Logger::logError);
+    }
+
+    private void showCopyright() {
+        getView().setCopyright(copyright);
+    }
+
+    public void updateCopyright() {
         nullifyEmptyFields(copyright);
 
         copyright.setEvent(ContextManager.getSelectedEvent());


### PR DESCRIPTION
Fixes #852 

Changes: Removed static Copyright field from the UpdateCopyrightFragment
Copyright fetched from the database.

Screenshots for the change: 
![videotogif_2018 03 30_13 00 47](https://user-images.githubusercontent.com/21277837/38129053-f7db5b16-341a-11e8-9a76-5cfe9081a1be.gif)
