### PR TITLE
fix: Runtime Validation in CreateCopyright BaseFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventActivity.java
@@ -26,11 +26,10 @@ public class AboutEventActivity extends AppCompatActivity implements HasSupportF
         setContentView(R.layout.about_event_activity);
 
         Bundle extras = getIntent().getExtras();
-        if (extras != null && extras.containsKey(EVENT_ID)) {
-            long id = extras.getLong(EVENT_ID);
-
-            IAboutEventVew aboutEventVew = (IAboutEventVew) getSupportFragmentManager().findFragmentById(R.id.about_event_fragment);
-            aboutEventVew.setEventId(id);
+        if (extras != null && extras.containsKey(EVENT_ID) && savedInstanceState == null) {
+            getSupportFragmentManager().beginTransaction()
+                .replace(R.id.fragment, AboutEventFragment.newInstance(extras.getLong(EVENT_ID)))
+                .commit();
         }
     }
 

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
@@ -4,7 +4,6 @@ import android.databinding.DataBindingUtil;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.support.design.widget.BottomSheetDialogFragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -37,6 +36,7 @@ public class AboutEventFragment extends BaseFragment<AboutEventPresenter> implem
     private AboutEventFragmentBinding binding;
     private SwipeRefreshLayout refreshLayout;
     private long eventId;
+    private static final String EVENT_ID = "id";
     private boolean creatingCopyright = true;
     private final CompositeDisposable compositeDisposable = new CompositeDisposable();
 
@@ -47,11 +47,22 @@ public class AboutEventFragment extends BaseFragment<AboutEventPresenter> implem
     @Inject
     ToolbarColorChanger toolbarColorChanger;
 
+    public static AboutEventFragment newInstance(long id) {
+        Bundle bundle = new Bundle();
+        bundle.putLong(EVENT_ID, id);
+        AboutEventFragment aboutEventFragment = new AboutEventFragment();
+        aboutEventFragment.setArguments(bundle);
+        return aboutEventFragment;
+    }
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         setHasOptionsMenu(true);
         binding = DataBindingUtil.inflate(inflater, R.layout.about_event_fragment, container, false);
+
+        Bundle bundle = getArguments();
+        eventId = bundle.getLong(EVENT_ID);
 
         AppCompatActivity activity = ((AppCompatActivity) getActivity());
         activity.setSupportActionBar(binding.toolbar);
@@ -113,11 +124,13 @@ public class AboutEventFragment extends BaseFragment<AboutEventPresenter> implem
         switch (item.getItemId()) {
             case R.id.action_create_change_copyright:
                 if (creatingCopyright) {
-                    BottomSheetDialogFragment bottomSheetDialogFragment = CreateCopyrightFragment.newInstance();
-                    bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
+                    getFragmentManager().beginTransaction()
+                        .replace(R.id.fragment, CreateCopyrightFragment.newInstance())
+                        .commit();
                 } else {
-                    BottomSheetDialogFragment bottomSheetDialogFragment = UpdateCopyrightFragment.newInstance(eventId);
-                    bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
+                    getFragmentManager().beginTransaction()
+                        .replace(R.id.fragment, UpdateCopyrightFragment.newInstance(eventId))
+                        .commit();
                 }
                 break;
             case R.id.action_delete_copyright:

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/CreateCopyrightPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/CreateCopyrightPresenter.java
@@ -16,6 +16,7 @@ public class CreateCopyrightPresenter extends BasePresenter<ICreateCopyrightView
 
     private final ICopyrightRepository copyrightRepository;
     private final Copyright copyright = new Copyright();
+    private static final int YEAR_LENGTH = 4;
 
     @Inject
     public CreateCopyrightPresenter(ICopyrightRepository copyrightRepository) {
@@ -31,6 +32,10 @@ public class CreateCopyrightPresenter extends BasePresenter<ICreateCopyrightView
         return copyright;
     }
 
+    public Long getParentEventId() {
+        return ContextManager.getSelectedEvent().id;
+    }
+
     protected void nullifyEmptyFields(Copyright copyright) {
         copyright.setHolderUrl(StringUtils.emptyToNull(copyright.getHolderUrl()));
         copyright.setLicence(StringUtils.emptyToNull(copyright.getLicence()));
@@ -39,8 +44,22 @@ public class CreateCopyrightPresenter extends BasePresenter<ICreateCopyrightView
         copyright.setLogoUrl(StringUtils.emptyToNull(copyright.getLogoUrl()));
     }
 
+    protected boolean verifyYear(Copyright copyright) {
+       if (copyright.getYear() == null)
+            return true;
+       else if (copyright.getYear().length() == YEAR_LENGTH)
+           return true;
+       else {
+           getView().showError("Please Enter a Valid Year");
+           return false;
+       }
+    }
+
     public void createCopyright() {
         nullifyEmptyFields(copyright);
+
+        if (!verifyYear(copyright))
+            return;
 
         copyright.setEvent(ContextManager.getSelectedEvent());
 

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/ICreateCopyrightView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/ICreateCopyrightView.java
@@ -1,5 +1,8 @@
 package org.fossasia.openevent.app.core.event.copyright;
 
+import android.support.design.widget.TextInputLayout;
+
+import org.fossasia.openevent.app.common.Function;
 import org.fossasia.openevent.app.common.mvp.view.Erroneous;
 import org.fossasia.openevent.app.common.mvp.view.Progressive;
 import org.fossasia.openevent.app.common.mvp.view.Successful;
@@ -7,4 +10,6 @@ import org.fossasia.openevent.app.common.mvp.view.Successful;
 public interface ICreateCopyrightView extends Progressive, Erroneous, Successful {
 
     void dismiss();
+
+    void validate(TextInputLayout textInputLayout, Function<String, Boolean> function, String str);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/UpdateCopyrightFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/UpdateCopyrightFragment.java
@@ -4,12 +4,16 @@ import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
 import org.fossasia.openevent.app.R;
-import org.fossasia.openevent.app.common.mvp.view.BaseBottomSheetFragment;
+import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
+import org.fossasia.openevent.app.core.event.about.AboutEventFragment;
 import org.fossasia.openevent.app.data.models.Copyright;
 import org.fossasia.openevent.app.databinding.CopyrightCreateLayoutBinding;
 import org.fossasia.openevent.app.ui.ViewUtils;
@@ -21,7 +25,7 @@ import dagger.Lazy;
 
 import static org.fossasia.openevent.app.ui.ViewUtils.showView;
 
-public class UpdateCopyrightFragment extends BaseBottomSheetFragment<UpdateCopyrightPresenter> implements IUpdateCopyrightView {
+public class UpdateCopyrightFragment extends BaseFragment<UpdateCopyrightPresenter> implements IUpdateCopyrightView {
 
     private static final String EVENT_ID = "id";
 
@@ -45,6 +49,17 @@ public class UpdateCopyrightFragment extends BaseBottomSheetFragment<UpdateCopyr
         binding =  DataBindingUtil.inflate(inflater, R.layout.copyright_create_layout, container, false);
         validator = new Validator(binding.form);
 
+        AppCompatActivity activity = ((AppCompatActivity) getActivity());
+        activity.setSupportActionBar(binding.toolbar);
+
+        ActionBar actionBar = activity.getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setHomeButtonEnabled(true);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+
+        setHasOptionsMenu(true);
+
         Bundle bundle = getArguments();
         copyrightId = bundle.getLong(EVENT_ID);
 
@@ -64,8 +79,20 @@ public class UpdateCopyrightFragment extends BaseBottomSheetFragment<UpdateCopyr
     }
 
     @Override
+    public void dismiss() {
+        getFragmentManager().beginTransaction()
+            .replace(R.id.fragment, AboutEventFragment.newInstance(getPresenter().getParentEventId()))
+            .commit();
+    }
+
+    @Override
     public void setCopyright(Copyright copyright) {
         binding.setCopyright(copyright);
+    }
+
+    @Override
+    protected int getTitle() {
+        return R.string.copyright;
     }
 
     @Override
@@ -85,6 +112,6 @@ public class UpdateCopyrightFragment extends BaseBottomSheetFragment<UpdateCopyr
 
     @Override
     public void onSuccess(String message) {
-        ViewUtils.showSnackbar(binding.getRoot(), message);
+        Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/UpdateCopyrightPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/UpdateCopyrightPresenter.java
@@ -16,6 +16,7 @@ public class UpdateCopyrightPresenter extends BasePresenter<IUpdateCopyrightView
 
     private final ICopyrightRepository copyrightRepository;
     private Copyright copyright;
+    private static final int YEAR_LENGTH = 4;
 
     @Inject
     public UpdateCopyrightPresenter(ICopyrightRepository copyrightRepository) {
@@ -27,12 +28,27 @@ public class UpdateCopyrightPresenter extends BasePresenter<IUpdateCopyrightView
         // Nothing to do
     }
 
+    public Long getParentEventId() {
+        return ContextManager.getSelectedEvent().id;
+    }
+
     private void nullifyEmptyFields(Copyright copyright) {
         copyright.setHolderUrl(StringUtils.emptyToNull(copyright.getHolderUrl()));
         copyright.setLicence(StringUtils.emptyToNull(copyright.getLicence()));
         copyright.setLicenceUrl(StringUtils.emptyToNull(copyright.getLicenceUrl()));
         copyright.setYear(StringUtils.emptyToNull(copyright.getYear()));
         copyright.setLogoUrl(StringUtils.emptyToNull(copyright.getLogoUrl()));
+    }
+
+    protected boolean verifyYear(Copyright copyright) {
+        if (copyright.getYear() == null)
+            return true;
+        else if (copyright.getYear().length() == YEAR_LENGTH)
+            return true;
+        else {
+            getView().showError("Please Enter a Valid Year");
+            return false;
+        }
     }
 
     public void loadCopyright(long eventId) {
@@ -50,6 +66,9 @@ public class UpdateCopyrightPresenter extends BasePresenter<IUpdateCopyrightView
 
     public void updateCopyright() {
         nullifyEmptyFields(copyright);
+
+        if (!verifyYear(copyright))
+            return;
 
         copyright.setEvent(ContextManager.getSelectedEvent());
 

--- a/app/src/main/res/layout/about_event_activity.xml
+++ b/app/src/main/res/layout/about_event_activity.xml
@@ -1,8 +1,11 @@
-<fragment xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/about_event_fragment"
-    android:name="org.fossasia.openevent.app.core.event.about.AboutEventFragment"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    tools:layout="@layout/about_event_fragment" />
+<layout>
+
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</layout>

--- a/app/src/main/res/layout/copyright_create_form.xml
+++ b/app/src/main/res/layout/copyright_create_form.xml
@@ -70,6 +70,7 @@
                 app:srcCompat="@drawable/ic_link" />
 
             <android.support.design.widget.TextInputLayout
+                android:id="@+id/copyright_holderUrl_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:padding="@dimen/spacing_extra_small">
@@ -108,6 +109,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/license_text"
                     android:text="@={copyright.licence}"
+                    app:validateEmpty="@{true}"
                     android:inputType="text" />
 
             </android.support.design.widget.TextInputLayout>
@@ -126,6 +128,7 @@
                 app:srcCompat="@drawable/ic_link" />
 
             <android.support.design.widget.TextInputLayout
+                android:id="@+id/copyright_licenceUrl_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:padding="@dimen/spacing_extra_small">
@@ -154,6 +157,7 @@
                 app:srcCompat="@drawable/ic_link" />
 
             <android.support.design.widget.TextInputLayout
+                android:id="@+id/copyright_logoUrl_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:padding="@dimen/spacing_extra_small">

--- a/app/src/main/res/layout/copyright_create_layout.xml
+++ b/app/src/main/res/layout/copyright_create_layout.xml
@@ -12,8 +12,34 @@
     </data>
 
     <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/main_content"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <android.support.design.widget.AppBarLayout
+                android:id="@+id/app_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:theme="@style/ThemeOverlay.AppCompat.ActionBar">
+
+                <android.support.v7.widget.Toolbar
+                    android:id="@+id/toolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="?attr/actionBarSize"
+                    app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+                    app:title="@string/copyright" />
+
+            </android.support.design.widget.AppBarLayout>
+
+    <android.support.design.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:background="@color/color_top_surface">
 
         <android.support.v4.widget.NestedScrollView
@@ -29,9 +55,10 @@
         <FrameLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="top|end"
+            android:layout_gravity="bottom|end"
+            android:layout_marginEnd="@dimen/spacing_normal"
             android:layout_marginRight="@dimen/spacing_normal"
-            android:layout_marginEnd="@dimen/spacing_normal">
+            android:layout_marginBottom="@dimen/spacing_normal">
 
             <android.support.design.widget.FloatingActionButton
                 android:id="@+id/submit"
@@ -39,7 +66,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 app:backgroundTint="@color/light_green_500"
-                app:fabSize="mini"
+                app:fabSize="normal"
                 app:srcCompat="@drawable/ic_check"
                 app:tint="@android:color/white" />
 
@@ -58,5 +85,8 @@
 
                 </FrameLayout>
         </FrameLayout>
+    </android.support.design.widget.CoordinatorLayout>
+
+    </LinearLayout>
     </android.support.design.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,7 @@
     <string name="use_date_time_picker">Use Picker</string>
     <string name="welcome">Hi, Organiser!</string>
     <string name="delete_copyright">Delete Copyright</string>
+    <string name="year_validation_error">Please Enter a Valid Year</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>

--- a/app/src/test/java/org/fossasia/openevent/app/unit/presenter/CreateCopyrightPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/unit/presenter/CreateCopyrightPresenterTest.java
@@ -21,7 +21,10 @@ import io.reactivex.android.plugins.RxAndroidPlugins;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(JUnit4.class)
@@ -49,6 +52,34 @@ public class CreateCopyrightPresenterTest {
     }
 
     @Test
+    public void shouldShowErrorOnInvalidYear() {
+        Copyright copyright = createCopyrightPresenter.getCopyright();
+        copyright.setYear("25");
+
+        createCopyrightPresenter.createCopyright();
+
+        verify(createCopyrightView).showError("Please Enter a Valid Year");
+        verify(copyrightRepository, never()).createCopyright(any());
+    }
+
+    @Test
+    public void shouldAcceptCorrectYear() {
+        Copyright copyright = createCopyrightPresenter.getCopyright();
+        copyright.setYear("2018");
+
+        when(copyrightRepository.createCopyright(copyright)).thenReturn(Observable.just(copyright));
+
+        createCopyrightPresenter.createCopyright();
+
+        InOrder inOrder = Mockito.inOrder(createCopyrightView);
+
+        inOrder.verify(createCopyrightView).showProgress(true);
+        inOrder.verify(createCopyrightView).onSuccess(anyString());
+        inOrder.verify(createCopyrightView).dismiss();
+        inOrder.verify(createCopyrightView).showProgress(false);
+    }
+
+    @Test
     public void shouldShowErrorOnFailure() {
         Copyright copyright = createCopyrightPresenter.getCopyright();
 
@@ -66,6 +97,7 @@ public class CreateCopyrightPresenterTest {
     @Test
     public void shouldShowSuccessOnCreated() {
         Copyright copyright = createCopyrightPresenter.getCopyright();
+        copyright.setYear(null);
 
         when(copyrightRepository.createCopyright(copyright)).thenReturn(Observable.just(copyright));
 


### PR DESCRIPTION
Fixes #712 

Changes: 
1. Changed AboutEventActivity to support all fragments(CreateCopyright, UpdateCopyright) from same about activity fragment container.
2. Added Runtime Validation of fields in CreateCopyrightFragment.
3. Added Validation for Year field on clicking submit. 
4. Changed CreateCopyright Fragment from BaseBottomSheetFragment to BaseFragment.
5. Changed UpdateCopyrightFragment from BaseBottomSheetFragment to BaseFragment.

Screenshots for the change: 
![20180330192802-7c011ad592 gif-2-mp4 com](https://user-images.githubusercontent.com/23634977/38145275-25e90076-3466-11e8-84a4-9d4419dd4f69.gif)
![20180330193450-7c011ad592 gif-2-mp4 com](https://user-images.githubusercontent.com/23634977/38145365-838b47e8-3466-11e8-9a68-c9393dea438a.gif)


