### PR TITLE
doc: add separate issue template

### DIFF
--- a/ISSUE_TEMPLATE/bug.md
+++ b/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,29 @@
+### Bug Report    
+
+**Actual Behaviour**
+
+Please state here what is currently happening.
+
+**Expected Behaviour**
+
+State here what the feature should enable the user to do.
+
+**Steps to reproduce it**
+
+Add steps to reproduce bugs or add information on the place where the feature should be implemented. Add links to a sample deployment or code.
+
+**LogCat for the issue**
+
+Provide logs for the crash here
+
+**Screenshots of the issue**
+
+Where-ever possible attach a screenshot of the issue.
+
+**Android version and Phone Model**
+
+Add the Android version and the phone model on which the issue was encountered.
+
+**Would you like to work on the issue?**
+
+Please let us know if you can work on it or the issue should be assigned to someone else.

--- a/ISSUE_TEMPLATE/chore.md
+++ b/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,9 @@
+### Chore
+
+**Description**
+
+Please describe the tools/files you want to update/upgrade.  
+
+**Would you like to work on the issue?**
+
+Please let us know if you can work on it or the issue should be assigned to someone else.

--- a/ISSUE_TEMPLATE/feature.md
+++ b/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,9 @@
+### Feature Request
+
+**Feature Description**
+
+Please describe the feature you want to add to the project.
+
+**Would you like to work on the issue?**
+
+Please let us know if you can work on it or the issue should be assigned to someone else.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Currently, the application is released in alpha phase at Google Play Store [here
 
 <a href='https://play.google.com/store/apps/details?id=org.fossasia.eventyay&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="80"/></a>
 
+Have an issue? Create one using these:
+
+[![Bug](https://img.shields.io/badge/issues-bug-red.svg)](https://github.com/fossasia/open-event-orga-app/issues/new?template=bug.md)
+[![Feature](https://img.shields.io/badge/issues-feature-green.svg)](https://github.com/fossasia/open-event-orga-app/issues/new?template=feature.md)
+[![Chore](https://img.shields.io/badge/issues-chore-blue.svg)](https://github.com/fossasia/open-event-orga-app/issues/new?template=chore.md)
+
 ## Roadmap
 
 Planned features & enhancements are:


### PR DESCRIPTION
Fixes #821 

Changes: Separate issue templates can now be used from the README.md