### PR TITLE
fix: App doesn't crash on creating new events

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/event/create/CreateEventActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/create/CreateEventActivity.java
@@ -2,12 +2,22 @@ package org.fossasia.openevent.app.core.event.create;
 
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import org.fossasia.openevent.app.R;
 
-public class CreateEventActivity extends AppCompatActivity {
+import javax.inject.Inject;
+
+import dagger.android.AndroidInjector;
+import dagger.android.DispatchingAndroidInjector;
+import dagger.android.support.HasSupportFragmentInjector;
+
+public class CreateEventActivity extends AppCompatActivity implements HasSupportFragmentInjector {
+
+    @Inject
+    DispatchingAndroidInjector<Fragment> fragmentDispatchingInjector;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -30,5 +40,10 @@ public class CreateEventActivity extends AppCompatActivity {
             default:
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public AndroidInjector<Fragment> supportFragmentInjector() {
+        return fragmentDispatchingInjector;
     }
 }


### PR DESCRIPTION
Fixes #861 
The app no longer crashes on creating new events.
