### PR TITLE
Add all fragments except dashboard, to backstack

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/main/MainActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/main/MainActivity.java
@@ -182,8 +182,6 @@ public class MainActivity extends BaseInjectActivity<MainPresenter> implements N
         Fragment fragment;
         FragmentTransaction ft = fragmentManager.beginTransaction();
 
-        isDashboardActive = true;
-
         switch (navItemId) {
             case R.id.nav_dashboard:
                 fragment = EventDashboardFragment.newInstance(eventId);
@@ -209,11 +207,12 @@ public class MainActivity extends BaseInjectActivity<MainPresenter> implements N
         }
 
         getSupportFragmentManager().popBackStack();
-        if (navItemId == R.id.nav_dashboard) {
+
+        isDashboardActive = navItemId == R.id.nav_dashboard;
+        if (isDashboardActive) {
             ft.replace(R.id.fragment_container, fragment);
         } else {
             ft.add(R.id.fragment_container, fragment).addToBackStack(null);
-            isDashboardActive = false;
         }
         ft.commit();
 

--- a/app/src/main/java/org/fossasia/openevent/app/core/settings/SettingsFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/settings/SettingsFragment.java
@@ -3,6 +3,9 @@ package org.fossasia.openevent.app.core.settings;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.preference.PreferenceManager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
 
 import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
 
@@ -14,6 +17,13 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
     public static SettingsFragment newInstance() {
         return new SettingsFragment();
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = super.onCreateView(inflater, container, savedInstanceState);
+        view.setBackgroundColor(getResources().getColor(R.color.color_top_surface));
+        return view;
     }
 
     @Override

--- a/app/src/main/res/layout/about_event_fragment.xml
+++ b/app/src/main/res/layout/about_event_fragment.xml
@@ -18,7 +18,8 @@
         android:id="@+id/main_content"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:fitsSystemWindows="true"
+        android:background="@color/color_top_surface">
 
         <android.support.design.widget.AppBarLayout
             android:id="@+id/app_bar"

--- a/app/src/main/res/layout/faqs_fragment.xml
+++ b/app/src/main/res/layout/faqs_fragment.xml
@@ -5,7 +5,8 @@
 
     <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="@color/color_top_surface">
 
         <FrameLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_attendees.xml
+++ b/app/src/main/res/layout/fragment_attendees.xml
@@ -13,7 +13,8 @@
 
     <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="@color/color_top_surface">
 
         <FrameLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/tickets_fragment.xml
+++ b/app/src/main/res/layout/tickets_fragment.xml
@@ -5,7 +5,8 @@
 
     <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="@color/color_top_surface">
 
         <FrameLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #682 

Changes: 
    1. All fragments are now being added to backstack after selection
    2. The background colour of SettingsFragment is changed to remove transparency (as it is added over DashboardFragment)

Screenshots of the change: 
![backstack](https://user-images.githubusercontent.com/35009811/38177705-de9fbcf0-3622-11e8-8d80-9c73c2827b70.gif)
