### PR TITLE
fix: Save token in AuthHolder

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/NetworkModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/NetworkModule.java
@@ -100,15 +100,14 @@ public class NetworkModule {
         return chain -> {
             Request original = chain.request();
 
-            String token = authHolder.getToken();
-
-            if (token == null) {
-                Timber.wtf("Someone tried to access resources without auth token. Maybe auth request?");
+            String authorization = authHolder.getAuthorization();
+            if (authorization == null) {
+                Timber.d("Someone tried to access resources without auth token. Maybe auth request?");
                 return chain.proceed(original);
             }
 
             Request request = original.newBuilder()
-                .header("Authorization", authHolder.getAuthorization())
+                .header("Authorization", authorization)
                 .method(original.method(), original.body())
                 .build();
 

--- a/app/src/main/java/org/fossasia/openevent/app/data/auth/AuthHolder.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/auth/AuthHolder.java
@@ -1,6 +1,7 @@
 package org.fossasia.openevent.app.data.auth;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 
 import org.fossasia.openevent.app.data.user.User;
 import org.fossasia.openevent.app.common.Constants;
@@ -14,7 +15,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
-public class AuthHolder {
+public final class AuthHolder {
 
     private static final String SHARED_PREFS_TOKEN = "token";
     private final Preferences sharedPreferenceModel;
@@ -27,13 +28,21 @@ public class AuthHolder {
     }
 
     public String getToken() {
-        if (token != null)
-            return token;
+        if (token == null)
+            token = sharedPreferenceModel.getString(SHARED_PREFS_TOKEN, null);
 
-        return sharedPreferenceModel.getString(SHARED_PREFS_TOKEN, null);
+        return token;
+    }
+
+    @VisibleForTesting
+    String getTokenRaw() {
+        return token;
     }
 
     public String getAuthorization() {
+        String token = getToken();
+        if (token == null)
+            return null;
         return JWTUtils.getAuthorization(token);
     }
 

--- a/app/src/test/java/org/fossasia/openevent/app/data/auth/AuthHolderTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/data/auth/AuthHolderTest.java
@@ -27,6 +27,7 @@ public class AuthHolderTest {
     private static final String UNEXPIRABLE_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
         ".eyJuYmYiOjE0OTU3NDU0MDAsImlhdCI6MTQ5NTc0NTQwMCwiZXhwIjoyNDk1ODMxODAwLCJpZGVudGl0eSI6MzQ0fQ" +
         ".A_aC4hwK8sixZk4k9gzmzidO1wj2hjy_EH573uorK-E";
+    private static final String TOKEN = "token";
 
     private AuthHolder authHolder;
 
@@ -64,9 +65,9 @@ public class AuthHolderTest {
 
     @Test
     public void shouldReturnStoredToken() {
-        when(preferenceModel.getString(any(), any())).thenReturn("token");
+        when(preferenceModel.getString(any(), any())).thenReturn(TOKEN);
 
-        assertEquals("token", authHolder.getToken());
+        assertEquals(TOKEN, authHolder.getToken());
     }
 
     @Test
@@ -109,6 +110,25 @@ public class AuthHolderTest {
 
         verify(preferenceModel).setLong(MainActivity.EVENT_KEY, -1);
         assertNull(ContextManager.getSelectedEvent());
+    }
+
+    // Regression Tests
+
+    @Test
+    public void shouldSetPrivateMember() {
+        assertNull(authHolder.getTokenRaw());
+
+        when(preferenceModel.getString(any(), any())).thenReturn(TOKEN);
+        assertEquals(TOKEN, authHolder.getToken());
+        assertEquals(TOKEN, authHolder.getTokenRaw());
+    }
+
+    @Test
+    public void authorizationShouldBeNull() {
+        assertNull(authHolder.getTokenRaw());
+
+        assertNull(authHolder.getToken());
+        assertNull(authHolder.getAuthorization());
     }
 
 }


### PR DESCRIPTION
- Set private member equal to token
- Use getToken() in getAuthorization()
- Return null from getAuthorization is token is null
- Change logic in Authenticator Interceptor

Fixes #881