### PR TITLE
Fix bug: Pressing back on create/edit copyright exits activity #884

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventActivity.java
@@ -2,6 +2,7 @@ package org.fossasia.openevent.app.core.event.about;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
@@ -17,6 +18,8 @@ public class AboutEventActivity extends AppCompatActivity implements HasSupportF
 
     public static final String EVENT_ID = "event_id";
 
+    private final FragmentManager fragmentManager = getSupportFragmentManager();
+
     @Inject
     DispatchingAndroidInjector<Fragment> dispatchingAndroidInjector;
 
@@ -27,8 +30,8 @@ public class AboutEventActivity extends AppCompatActivity implements HasSupportF
 
         Bundle extras = getIntent().getExtras();
         if (extras != null && extras.containsKey(EVENT_ID) && savedInstanceState == null) {
-            getSupportFragmentManager().beginTransaction()
-                .replace(R.id.fragment, AboutEventFragment.newInstance(extras.getLong(EVENT_ID)))
+            fragmentManager.beginTransaction()
+                .add(R.id.fragment, AboutEventFragment.newInstance(extras.getLong(EVENT_ID)))
                 .commit();
         }
     }
@@ -37,7 +40,10 @@ public class AboutEventActivity extends AppCompatActivity implements HasSupportF
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
-                finish();
+                if (fragmentManager.getBackStackEntryCount() > 0)
+                    fragmentManager.popBackStack();
+                else
+                    finish();
                 return true;
             default:
         }

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
@@ -125,11 +125,13 @@ public class AboutEventFragment extends BaseFragment<AboutEventPresenter> implem
             case R.id.action_create_change_copyright:
                 if (creatingCopyright) {
                     getFragmentManager().beginTransaction()
-                        .replace(R.id.fragment, CreateCopyrightFragment.newInstance())
+                        .add(R.id.fragment, CreateCopyrightFragment.newInstance())
+                        .addToBackStack(null)
                         .commit();
                 } else {
                     getFragmentManager().beginTransaction()
-                        .replace(R.id.fragment, UpdateCopyrightFragment.newInstance(eventId))
+                        .add(R.id.fragment, UpdateCopyrightFragment.newInstance(eventId))
+                        .addToBackStack(null)
                         .commit();
                 }
                 break;

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/CreateCopyrightFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/CreateCopyrightFragment.java
@@ -20,7 +20,6 @@ import android.widget.Toast;
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.common.Function;
 import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
-import org.fossasia.openevent.app.core.event.about.AboutEventFragment;
 import org.fossasia.openevent.app.databinding.CopyrightCreateLayoutBinding;
 import org.fossasia.openevent.app.ui.ViewUtils;
 import org.fossasia.openevent.app.utils.ValidateUtils;
@@ -119,9 +118,7 @@ public class CreateCopyrightFragment extends BaseFragment<CreateCopyrightPresent
 
     @Override
     public void dismiss() {
-        getFragmentManager().beginTransaction()
-            .replace(R.id.fragment, AboutEventFragment.newInstance(getPresenter().getParentEventId()))
-            .commit();
+        getFragmentManager().popBackStack();
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/UpdateCopyrightFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/copyright/update/UpdateCopyrightFragment.java
@@ -13,7 +13,6 @@ import android.widget.Toast;
 
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
-import org.fossasia.openevent.app.core.event.about.AboutEventFragment;
 import org.fossasia.openevent.app.data.copyright.Copyright;
 import org.fossasia.openevent.app.databinding.CopyrightCreateLayoutBinding;
 import org.fossasia.openevent.app.ui.ViewUtils;
@@ -80,9 +79,7 @@ public class UpdateCopyrightFragment extends BaseFragment<UpdateCopyrightPresent
 
     @Override
     public void dismiss() {
-        getFragmentManager().beginTransaction()
-            .replace(R.id.fragment, AboutEventFragment.newInstance(getPresenter().getParentEventId()))
-            .commit();
+        getFragmentManager().popBackStack();
     }
 
     @Override


### PR DESCRIPTION
Fixes #884 

Changes: 
    1. Add Copyright Fragment to backstack
    2. Change activity's home action to `finish()` only when there's no fragment in backstack

Screenshots of the change: 
![backstackcopyright](https://user-images.githubusercontent.com/35009811/38616777-cbc293c2-3db2-11e8-9e4e-6d3616e95b92.gif)
