### PR TITLE
fix: Pressing back pops from backstack

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/organizer/detail/OrganizerDetailActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/organizer/detail/OrganizerDetailActivity.java
@@ -2,6 +2,7 @@ package org.fossasia.openevent.app.core.organizer.detail;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
@@ -15,6 +16,8 @@ import dagger.android.support.HasSupportFragmentInjector;
 
 public class OrganizerDetailActivity extends AppCompatActivity implements HasSupportFragmentInjector {
 
+    private final FragmentManager fragmentManager = getSupportFragmentManager();
+
     @Inject
     DispatchingAndroidInjector<Fragment> dispatchingAndroidInjector;
 
@@ -24,7 +27,7 @@ public class OrganizerDetailActivity extends AppCompatActivity implements HasSup
         setContentView(R.layout.organizer_detail_activity);
 
         if (savedInstanceState == null) {
-            getSupportFragmentManager().beginTransaction()
+            fragmentManager.beginTransaction()
                 .replace(R.id.fragment, new OrganizerDetailFragment())
                 .commit();
         }
@@ -34,7 +37,10 @@ public class OrganizerDetailActivity extends AppCompatActivity implements HasSup
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
-                finish();
+                if (fragmentManager.getBackStackEntryCount() > 0)
+                    fragmentManager.popBackStack();
+                else
+                    finish();
                 return true;
             default:
         }

--- a/app/src/main/java/org/fossasia/openevent/app/core/organizer/detail/OrganizerDetailFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/organizer/detail/OrganizerDetailFragment.java
@@ -82,6 +82,7 @@ public class OrganizerDetailFragment extends BaseFragment<OrganizerDetailPresent
             case R.id.update_organizer:
                 getFragmentManager().beginTransaction()
                     .replace(R.id.fragment, UpdateOrganizerInfoFragment.newInstance())
+                    .addToBackStack(null)
                     .commit();
                 break;
             default:

--- a/app/src/main/java/org/fossasia/openevent/app/core/organizer/update/UpdateOrganizerInfoFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/organizer/update/UpdateOrganizerInfoFragment.java
@@ -20,7 +20,6 @@ import android.widget.Toast;
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.common.Function;
 import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
-import org.fossasia.openevent.app.core.organizer.detail.OrganizerDetailFragment;
 import org.fossasia.openevent.app.data.user.User;
 import org.fossasia.openevent.app.databinding.UpdateOrganizerLayoutBinding;
 import org.fossasia.openevent.app.ui.ViewUtils;
@@ -129,9 +128,7 @@ public class UpdateOrganizerInfoFragment extends BaseFragment<UpdateOrganizerInf
 
     @Override
     public void dismiss() {
-        getFragmentManager().beginTransaction()
-            .replace(R.id.fragment, new OrganizerDetailFragment())
-            .commit();
+        getFragmentManager().popBackStack();
     }
 
     @Override


### PR DESCRIPTION
Fixes #885 

Changes:
The edit organizer info fragment was added to backstack and the onBackPressed( ) was overridden so that when the count of number of fragment in backstack is greater than one , then the fragment should pop from the backstack and if count is 0 , activity can be exited.