### PR TITLE
fix: remove copyright create/delete/edit options from about event men…

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
@@ -8,9 +8,6 @@ import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -73,6 +70,9 @@ public class AboutEventFragment extends BaseFragment<AboutEventPresenter> implem
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
+        handleVisibility();
+        addCopyrightListeners();
+
         return binding.getRoot();
     }
 
@@ -114,47 +114,35 @@ public class AboutEventFragment extends BaseFragment<AboutEventPresenter> implem
         });
     }
 
-    @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        inflater.inflate(R.menu.menu_about_event, menu);
+    private void addCopyrightListeners() {
+        binding.detail.actionCreateCopyright.setOnClickListener(view -> {
+            getFragmentManager().beginTransaction()
+                .add(R.id.fragment, CreateCopyrightFragment.newInstance())
+                .addToBackStack(null)
+                .commit();
+        });
+
+        binding.detail.actionChangeCopyright.setOnClickListener(view -> {
+            getFragmentManager().beginTransaction()
+                .add(R.id.fragment, UpdateCopyrightFragment.newInstance(eventId))
+                .addToBackStack(null)
+                .commit();
+        });
+
+        binding.detail.actionDeleteCopyright.setOnClickListener(view -> {
+            getPresenter().deleteCopyright(getPresenter().getCopyright().getId());
+        });
     }
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_create_change_copyright:
-                if (creatingCopyright) {
-                    getFragmentManager().beginTransaction()
-                        .replace(R.id.fragment, CreateCopyrightFragment.newInstance())
-                        .commit();
-                } else {
-                    getFragmentManager().beginTransaction()
-                        .replace(R.id.fragment, UpdateCopyrightFragment.newInstance(eventId))
-                        .commit();
-                }
-                break;
-            case R.id.action_delete_copyright:
-                getPresenter().deleteCopyright(getPresenter().getCopyright().getId());
-                break;
-            default:
-                // No implementation
-        }
-        return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public void onPrepareOptionsMenu(Menu menu) {
-        super.onPrepareOptionsMenu(menu);
+    public void handleVisibility() {
         if (creatingCopyright) {
-            MenuItem menuItem = menu.findItem(R.id.action_create_change_copyright);
-            menuItem.setTitle(R.string.create_copyright);
-            menuItem = menu.findItem(R.id.action_delete_copyright);
-            menuItem.setVisible(false);
+            binding.detail.actionChangeCopyright.setVisibility(View.GONE);
+            binding.detail.actionDeleteCopyright.setVisibility(View.GONE);
+            binding.detail.actionCreateCopyright.setVisibility(View.VISIBLE);
         } else {
-            MenuItem menuItem = menu.findItem(R.id.action_create_change_copyright);
-            menuItem.setTitle(R.string.edit_copyright);
-            menuItem = menu.findItem(R.id.action_delete_copyright);
-            menuItem.setVisible(true);
+            binding.detail.actionChangeCopyright.setVisibility(View.VISIBLE);
+            binding.detail.actionDeleteCopyright.setVisibility(View.VISIBLE);
+            binding.detail.actionCreateCopyright.setVisibility(View.GONE);
         }
     }
 
@@ -186,7 +174,7 @@ public class AboutEventFragment extends BaseFragment<AboutEventPresenter> implem
     @Override
     public void changeCopyrightMenuItem(boolean creatingCopyright) {
         this.creatingCopyright = creatingCopyright;
-        getActivity().invalidateOptionsMenu();
+        handleVisibility();
     }
 
     @Override

--- a/app/src/main/res/drawable/ic_edit.xml
+++ b/app/src/main/res/drawable/ic_edit.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="#555"
         android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
 </vector>

--- a/app/src/main/res/layout/about_event_detail.xml
+++ b/app/src/main/res/layout/about_event_detail.xml
@@ -329,23 +329,55 @@
             <android.support.v7.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="@dimen/spacing_medium"
-                android:visibility='@{ copyright == null ? View.GONE : View.VISIBLE }'>
+                android:layout_margin="@dimen/spacing_medium">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
-                    <TextView
-                        android:layout_width="match_parent"
+                    <LinearLayout
                         android:layout_height="wrap_content"
-                        android:background="#dedede"
-                        android:padding="@dimen/spacing_small"
-                        android:text="@string/copyright"
+                        android:layout_width="match_parent"
                         android:textAppearance="@style/TextAppearance.AppCompat.Headline"
-                        android:textColor="?android:textColorSecondary" />
+                        android:orientation="horizontal">
+                        <TextView
+                            android:layout_height="wrap_content"
+                            android:layout_width="0dp"
+                            android:layout_weight="1"
+                            android:background="#dedede"
+                            android:padding="@dimen/spacing_small"
+                            android:text="@string/copyright"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+                            android:textColor="?android:textColorSecondary" />
 
+                        <ImageButton
+                            android:id="@+id/action_create_copyright"
+                            android:layout_width="@dimen/spacing_larger"
+                            android:layout_height="@dimen/spacing_larger"
+                            android:background="#dedede"
+                            android:tint="@color/menu_icon_color"
+                            android:contentDescription="@string/create_copyright"
+                            app:srcCompat="@drawable/ic_add" />
+
+                        <ImageButton
+                            android:id="@+id/action_change_copyright"
+                            android:layout_width="@dimen/spacing_larger"
+                            android:layout_height="@dimen/spacing_larger"
+                            android:background="#dedede"
+                            android:contentDescription="@string/edit_copyright"
+                            app:srcCompat="@drawable/ic_edit" />
+
+
+                        <ImageButton
+                            android:id="@+id/action_delete_copyright"
+                            android:layout_width="@dimen/spacing_larger"
+                            android:layout_height="@dimen/spacing_larger"
+                            android:background="#dedede"
+                            android:contentDescription="@string/delete_copyright"
+                            app:srcCompat="@drawable/ic_delete" />
+
+                    </LinearLayout>
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -354,6 +386,7 @@
                         android:drawableStart="@{ @drawable/ic_person }"
                         android:gravity="center_vertical"
                         android:padding="@dimen/spacing_small"
+                        android:visibility='@{ copyright.holder == null ? View.GONE : View.VISIBLE }'
                         android:text='@{ copyright.holder }' />
 
                     <TextView
@@ -364,6 +397,7 @@
                         android:drawableStart="@{ @drawable/ic_events }"
                         android:gravity="center_vertical"
                         android:padding="@dimen/spacing_small"
+                        android:visibility='@{ copyright.year == null ? View.GONE : View.VISIBLE }'
                         android:text='@{ copyright.year }' />
 
                     <TextView
@@ -374,6 +408,7 @@
                         android:drawableStart="@{ @drawable/ic_copyright }"
                         android:gravity="center_vertical"
                         android:padding="@dimen/spacing_small"
+                        android:visibility='@{ copyright.licence == null ? View.GONE : View.VISIBLE }'
                         android:text='@{ copyright.licence }' />
 
                     <TextView
@@ -384,6 +419,7 @@
                         android:drawableStart="@{ @drawable/ic_email }"
                         android:gravity="center_vertical"
                         android:padding="@dimen/spacing_small"
+                        android:visibility='@{ copyright.licenceUrl == null ? View.GONE : View.VISIBLE }'
                         android:text='@{ copyright.licenceUrl }' />
 
 


### PR DESCRIPTION
Fixes #887

Changes: create buttons on the copyright textview to create/edit and delete copyrights and removed them from the overflow menu. 

Screenshots for the change:
![screenshot_1523640464](https://user-images.githubusercontent.com/25455546/38749246-90f6ea28-3f6e-11e8-8388-784984d89403.png)
![screenshot_1523652359](https://user-images.githubusercontent.com/25455546/38757577-272cee22-3f8b-11e8-8040-3361fec08898.png)

