### PR TITLE
feat: List of Session for Event

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/ApiModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/ApiModule.java
@@ -6,6 +6,7 @@ import org.fossasia.openevent.app.data.copyright.CopyrightApi;
 import org.fossasia.openevent.app.data.event.EventApi;
 import org.fossasia.openevent.app.data.faq.FaqApi;
 import org.fossasia.openevent.app.data.feedback.FeedbackApi;
+import org.fossasia.openevent.app.data.session.SessionApi;
 import org.fossasia.openevent.app.data.ticket.TicketApi;
 import org.fossasia.openevent.app.data.tracks.TrackApi;
 import org.fossasia.openevent.app.data.user.UserApi;
@@ -71,5 +72,11 @@ public class ApiModule {
     @Singleton
     UserApi providesUserApi(Retrofit retrofit) {
         return retrofit.create(UserApi.class);
+    }
+
+    @Provides
+    @Singleton
+    SessionApi providesSessionApi(Retrofit retrofit) {
+        return retrofit.create(SessionApi.class);
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/ChangeListenerModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/ChangeListenerModule.java
@@ -5,6 +5,7 @@ import org.fossasia.openevent.app.data.copyright.Copyright;
 import org.fossasia.openevent.app.data.db.DatabaseChangeListener;
 import org.fossasia.openevent.app.data.db.DbFlowDatabaseChangeListener;
 import org.fossasia.openevent.app.data.faq.Faq;
+import org.fossasia.openevent.app.data.session.Session;
 import org.fossasia.openevent.app.data.ticket.Ticket;
 import org.fossasia.openevent.app.data.tracks.Track;
 
@@ -37,5 +38,10 @@ public class ChangeListenerModule {
     @Provides
     DatabaseChangeListener<Track> providesTrackChangeListener() {
         return new DbFlowDatabaseChangeListener<>(Track.class);
+    }
+
+    @Provides
+    DatabaseChangeListener<Session> providesSessionChangeListener() {
+        return new DbFlowDatabaseChangeListener<>(Session.class);
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/NetworkModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/NetworkModule.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.jasminb.jsonapi.retrofit.JSONAPIConverterFactory;
 
 import org.fossasia.openevent.app.OrgaProvider;
+import org.fossasia.openevent.app.data.session.Session;
 import org.fossasia.openevent.app.data.user.User;
 import org.fossasia.openevent.app.common.Constants;
 import org.fossasia.openevent.app.data.attendee.Attendee;
@@ -39,6 +40,7 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 import timber.log.Timber;
 
 @Module(includes = ApiModule.class)
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 public class NetworkModule {
 
     @Provides
@@ -55,7 +57,7 @@ public class NetworkModule {
     @Provides
     Class[] providesMappedClasses() {
         return new Class[]{Event.class, Attendee.class, Ticket.class, User.class,
-            EventStatistics.class, Faq.class, Copyright.class, Feedback.class, Track.class};
+            EventStatistics.class, Faq.class, Copyright.class, Feedback.class, Track.class, Session.class};
     }
 
     @Provides

--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/RepoModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/RepoModule.java
@@ -12,6 +12,8 @@ import org.fossasia.openevent.app.data.faq.FaqRepository;
 import org.fossasia.openevent.app.data.faq.FaqRepositoryImpl;
 import org.fossasia.openevent.app.data.feedback.FeedbackRepository;
 import org.fossasia.openevent.app.data.feedback.FeedbackRepositoryImpl;
+import org.fossasia.openevent.app.data.session.SessionRepository;
+import org.fossasia.openevent.app.data.session.SessionRepositoryImpl;
 import org.fossasia.openevent.app.data.ticket.TicketRepository;
 import org.fossasia.openevent.app.data.ticket.TicketRepositoryImpl;
 import org.fossasia.openevent.app.data.tracks.TrackRepository;
@@ -62,4 +64,8 @@ public abstract class RepoModule {
     @Binds
     @Singleton
     abstract UserRepository bindsUserRepository(UserRepositoryImpl userRepository);
+
+    @Binds
+    @Singleton
+    abstract SessionRepository bindsSessionRepository(SessionRepositoryImpl sessionRepository);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/android/MainFragmentBuildersModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/android/MainFragmentBuildersModule.java
@@ -7,6 +7,7 @@ import org.fossasia.openevent.app.core.event.list.EventListFragment;
 import org.fossasia.openevent.app.core.faq.create.CreateFaqFragment;
 import org.fossasia.openevent.app.core.faq.list.FaqListFragment;
 import org.fossasia.openevent.app.core.feedback.list.FeedbackListFragment;
+import org.fossasia.openevent.app.core.session.list.SessionsFragment;
 import org.fossasia.openevent.app.core.settings.SettingsFragment;
 import org.fossasia.openevent.app.core.ticket.create.CreateTicketFragment;
 import org.fossasia.openevent.app.core.ticket.detail.TicketDetailFragment;
@@ -71,5 +72,9 @@ public abstract class MainFragmentBuildersModule {
 
     @ContributesAndroidInjector
     abstract CreateTrackFragment contributeCreateTrackFragment();
+
+    // Session
+    @ContributesAndroidInjector
+    abstract SessionsFragment contributeSessionFragment();
 }
 

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/about/AboutEventFragment.java
@@ -121,7 +121,7 @@ public class AboutEventFragment extends BaseFragment<AboutEventPresenter> implem
                 .addToBackStack(null)
                 .commit();
         });
-      
+
         binding.detail.actionChangeCopyright.setOnClickListener(view -> {
             getFragmentManager().beginTransaction()
                 .add(R.id.fragment, UpdateCopyrightFragment.newInstance(eventId))

--- a/app/src/main/java/org/fossasia/openevent/app/core/session/list/SessionsAdapter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/session/list/SessionsAdapter.java
@@ -1,0 +1,39 @@
+package org.fossasia.openevent.app.core.session.list;
+
+import android.databinding.DataBindingUtil;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import org.fossasia.openevent.app.R;
+import org.fossasia.openevent.app.core.session.list.viewholder.SessionViewHolder;
+import org.fossasia.openevent.app.data.session.Session;
+
+import java.util.List;
+
+public class SessionsAdapter extends RecyclerView.Adapter<SessionViewHolder> {
+
+    private final List<Session> sessions;
+
+    public SessionsAdapter(SessionsPresenter sessionsPresenter) {
+        this.sessions = sessionsPresenter.getSessions();
+    }
+
+    @NonNull
+    @Override
+    public SessionViewHolder onCreateViewHolder(@NonNull ViewGroup viewGroup, int position) {
+        return new SessionViewHolder(DataBindingUtil.inflate(LayoutInflater.from(viewGroup.getContext()),
+                R.layout.session_layout, viewGroup, false));
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull SessionViewHolder sessionViewHolder, int position) {
+        sessionViewHolder.bind(sessions.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return sessions.size();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/session/list/SessionsFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/session/list/SessionsFragment.java
@@ -1,11 +1,9 @@
-package org.fossasia.openevent.app.core.track.list;
+package org.fossasia.openevent.app.core.session.list;
 
 import android.content.Context;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.design.widget.BottomSheetDialogFragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
@@ -17,10 +15,9 @@ import android.view.ViewGroup;
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
 import org.fossasia.openevent.app.core.main.MainActivity;
-import org.fossasia.openevent.app.core.session.list.SessionsFragment;
-import org.fossasia.openevent.app.core.track.create.CreateTrackFragment;
-import org.fossasia.openevent.app.data.tracks.Track;
-import org.fossasia.openevent.app.databinding.TracksFragmentBinding;
+import org.fossasia.openevent.app.data.ContextUtils;
+import org.fossasia.openevent.app.data.session.Session;
+import org.fossasia.openevent.app.databinding.SessionsFragmentBinding;
 import org.fossasia.openevent.app.ui.ViewUtils;
 
 import java.util.List;
@@ -29,23 +26,27 @@ import javax.inject.Inject;
 
 import dagger.Lazy;
 
-public class TracksFragment extends BaseFragment<TracksPresenter> implements TracksView {
+public class SessionsFragment extends BaseFragment<SessionsPresenter> implements SessionsView {
+
     private Context context;
-    private long eventId;
+    private long trackId;
 
     @Inject
-    Lazy<TracksPresenter> tracksPresenter;
+    ContextUtils utilModel;
 
-    private TracksAdapter tracksAdapter;
-    private TracksFragmentBinding binding;
+    @Inject
+    Lazy<SessionsPresenter> sessionsPresenter;
+
+    private SessionsAdapter sessionsAdapter;
+    private SessionsFragmentBinding binding;
     private SwipeRefreshLayout refreshLayout;
 
     private boolean initialized;
 
-    public static TracksFragment newInstance(long eventId) {
-        TracksFragment fragment = new TracksFragment();
+    public static SessionsFragment newInstance(long trackId) {
+        SessionsFragment fragment = new SessionsFragment();
         Bundle args = new Bundle();
-        args.putLong(MainActivity.EVENT_KEY, eventId);
+        args.putLong(MainActivity.EVENT_KEY, trackId);
         fragment.setArguments(args);
         return fragment;
     }
@@ -55,19 +56,15 @@ public class TracksFragment extends BaseFragment<TracksPresenter> implements Tra
         super.onCreate(savedInstanceState);
 
         context = getContext();
+
         if (getArguments() != null)
-            eventId = getArguments().getLong(MainActivity.EVENT_KEY);
+            trackId = getArguments().getLong(MainActivity.EVENT_KEY);
     }
 
     @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        binding = DataBindingUtil.inflate(inflater, R.layout.tracks_fragment, container, false);
-
-        binding.createTrackFab.setOnClickListener(view -> {
-            BottomSheetDialogFragment bottomSheetDialogFragment = CreateTrackFragment.newInstance();
-            bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
-        });
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        binding = DataBindingUtil.inflate(inflater, R.layout.sessions_fragment, container, false);
 
         return binding.getRoot();
     }
@@ -77,7 +74,7 @@ public class TracksFragment extends BaseFragment<TracksPresenter> implements Tra
         super.onStart();
         setupRecyclerView();
         setupRefreshListener();
-        getPresenter().attach(eventId, this);
+        getPresenter().attach(trackId, this);
         getPresenter().start();
 
         initialized = true;
@@ -85,7 +82,7 @@ public class TracksFragment extends BaseFragment<TracksPresenter> implements Tra
 
     @Override
     protected int getTitle() {
-        return R.string.tracks;
+        return R.string.session;
     }
 
     @Override
@@ -96,30 +93,27 @@ public class TracksFragment extends BaseFragment<TracksPresenter> implements Tra
 
     private void setupRecyclerView() {
         if (!initialized) {
-            tracksAdapter = new TracksAdapter(getPresenter());
+            sessionsAdapter = new SessionsAdapter(getPresenter());
 
-            RecyclerView recyclerView = binding.tracksRecyclerView;
+            RecyclerView recyclerView = binding.sessionsRecyclerView;
             recyclerView.setLayoutManager(new LinearLayoutManager(context));
-            recyclerView.setAdapter(tracksAdapter);
+            recyclerView.setAdapter(sessionsAdapter);
             recyclerView.setItemAnimator(new DefaultItemAnimator());
         }
     }
 
     private void setupRefreshListener() {
         refreshLayout = binding.swipeContainer;
-        refreshLayout.setColorSchemeColors(getResources().getColor(R.color.color_accent));
+        refreshLayout.setColorSchemeColors(utilModel.getResourceColor(R.color.color_accent));
         refreshLayout.setOnRefreshListener(() -> {
             refreshLayout.setRefreshing(false);
-            getPresenter().loadTracks(true);
+            getPresenter().loadSessions(true);
         });
     }
 
-    public void openSessionsFragment(long trackId) {
-        getFragmentManager().popBackStack();
-        getFragmentManager().beginTransaction()
-            .replace(R.id.fragment_container, SessionsFragment.newInstance(trackId))
-            .addToBackStack(null)
-            .commit();
+    @Override
+    public Lazy<SessionsPresenter> getPresenterProvider() {
+        return sessionsPresenter;
     }
 
     @Override
@@ -135,21 +129,16 @@ public class TracksFragment extends BaseFragment<TracksPresenter> implements Tra
     @Override
     public void onRefreshComplete(boolean success) {
         if (success)
-            ViewUtils.showSnackbar(binding.tracksRecyclerView, R.string.refresh_complete);
+            ViewUtils.showSnackbar(binding.sessionsRecyclerView, R.string.refresh_complete);
     }
 
     @Override
-    public void showResults(List<Track> items) {
-        tracksAdapter.notifyDataSetChanged();
+    public void showResults(List<Session> items) {
+        sessionsAdapter.notifyDataSetChanged();
     }
 
     @Override
     public void showEmptyView(boolean show) {
         ViewUtils.showView(binding.emptyView, show);
-    }
-
-    @Override
-    protected Lazy<TracksPresenter> getPresenterProvider() {
-        return tracksPresenter;
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/session/list/SessionsPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/session/list/SessionsPresenter.java
@@ -1,0 +1,78 @@
+package org.fossasia.openevent.app.core.session.list;
+
+import com.raizlabs.android.dbflow.structure.BaseModel;
+
+import org.fossasia.openevent.app.common.mvp.presenter.AbstractDetailPresenter;
+import org.fossasia.openevent.app.common.rx.Logger;
+import org.fossasia.openevent.app.data.db.DatabaseChangeListener;
+import org.fossasia.openevent.app.data.db.DbFlowDatabaseChangeListener;
+import org.fossasia.openevent.app.data.session.Session;
+import org.fossasia.openevent.app.data.session.SessionRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import io.reactivex.Observable;
+import io.reactivex.schedulers.Schedulers;
+
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.dispose;
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.emptiable;
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.progressiveErroneousRefresh;
+
+public class SessionsPresenter extends AbstractDetailPresenter<Long, SessionsView> {
+
+    private final List<Session> sessions = new ArrayList<>();
+    private final SessionRepository sessionRepository;
+    private final DatabaseChangeListener<Session> sessionChangeListener;
+
+    @Inject
+    public SessionsPresenter(SessionRepository sessionRepository, DatabaseChangeListener<Session> sessionChangeListener) {
+        this.sessionRepository = sessionRepository;
+        this.sessionChangeListener = sessionChangeListener;
+    }
+
+    @Override
+    public void start() {
+        loadSessions(false);
+        listenChanges();
+    }
+
+    @Override
+    public void detach() {
+        super.detach();
+        sessionChangeListener.stopListening();
+    }
+
+    public void loadSessions(boolean forceReload) {
+        getSessionSource(forceReload)
+            .compose(dispose(getDisposable()))
+            .compose(progressiveErroneousRefresh(getView(), forceReload))
+            .toList()
+            .compose(emptiable(getView(), sessions))
+            .subscribe(Logger::logSuccess, Logger::logError);
+    }
+
+    private Observable<Session> getSessionSource(boolean forceReload) {
+        if (!forceReload && !sessions.isEmpty() && isRotated())
+            return Observable.fromIterable(sessions);
+        else {
+            return sessionRepository.getSessions(getId(), forceReload);
+        }
+    }
+
+    private void listenChanges() {
+        sessionChangeListener.startListening();
+        sessionChangeListener.getNotifier()
+            .compose(dispose(getDisposable()))
+            .map(DbFlowDatabaseChangeListener.ModelChange::getAction)
+            .filter(action -> action.equals(BaseModel.Action.INSERT))
+            .subscribeOn(Schedulers.io())
+            .subscribe(sessionModelChange -> loadSessions(false), Logger::logError);
+    }
+
+    public List<Session> getSessions() {
+        return sessions;
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/session/list/SessionsView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/session/list/SessionsView.java
@@ -1,12 +1,10 @@
-package org.fossasia.openevent.app.core.track.list;
+package org.fossasia.openevent.app.core.session.list;
 
 import org.fossasia.openevent.app.common.mvp.view.Emptiable;
 import org.fossasia.openevent.app.common.mvp.view.Erroneous;
 import org.fossasia.openevent.app.common.mvp.view.Progressive;
 import org.fossasia.openevent.app.common.mvp.view.Refreshable;
-import org.fossasia.openevent.app.data.tracks.Track;
+import org.fossasia.openevent.app.data.session.Session;
 
-public interface TracksView extends Progressive, Erroneous, Refreshable, Emptiable<Track> {
-
-    void openSessionsFragment(long trackId);
+public interface SessionsView extends Progressive, Erroneous, Refreshable, Emptiable<Session> {
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/session/list/viewholder/SessionViewHolder.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/session/list/viewholder/SessionViewHolder.java
@@ -1,0 +1,21 @@
+package org.fossasia.openevent.app.core.session.list.viewholder;
+
+import android.support.v7.widget.RecyclerView;
+
+import org.fossasia.openevent.app.data.session.Session;
+import org.fossasia.openevent.app.databinding.SessionLayoutBinding;
+
+public class SessionViewHolder extends RecyclerView.ViewHolder {
+
+    private final SessionLayoutBinding binding;
+
+    public SessionViewHolder(SessionLayoutBinding binding) {
+        super(binding.getRoot());
+        this.binding = binding;
+    }
+
+    public void bind(Session session) {
+        binding.setSession(session);
+        binding.executePendingBindings();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/track/list/TracksAdapter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/track/list/TracksAdapter.java
@@ -14,17 +14,23 @@ import java.util.List;
 
 public class TracksAdapter extends RecyclerView.Adapter<TracksViewHolder> {
     private final List<Track> tracks;
+    private final TracksPresenter tracksPresenter;
 
     public TracksAdapter(TracksPresenter tracksPresenter) {
+        this.tracksPresenter = tracksPresenter;
         this.tracks = tracksPresenter.getTracks();
     }
 
     @NonNull
     @Override
     public TracksViewHolder onCreateViewHolder(@NonNull ViewGroup viewGroup, int position) {
-        return new TracksViewHolder(
+        TracksViewHolder tracksViewHolder = new TracksViewHolder(
             DataBindingUtil.inflate(LayoutInflater.from(viewGroup.getContext()),
                 R.layout.track_item, viewGroup, false));
+
+        tracksViewHolder.setClickAction(tracksPresenter::openSessions);
+
+        return tracksViewHolder;
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/openevent/app/core/track/list/TracksPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/track/list/TracksPresenter.java
@@ -94,4 +94,8 @@ public class TracksPresenter extends AbstractDetailPresenter<Long, TracksView> {
             return Color.BLACK;
         }
     }
+
+    public void openSessions(Long trackId) {
+        getView().openSessionsFragment(trackId);
+    }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/track/list/viewholder/TracksViewHolder.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/track/list/viewholder/TracksViewHolder.java
@@ -2,18 +2,31 @@ package org.fossasia.openevent.app.core.track.list.viewholder;
 
 import android.support.v7.widget.RecyclerView;
 
+import org.fossasia.openevent.app.common.Pipe;
 import org.fossasia.openevent.app.data.tracks.Track;
 import org.fossasia.openevent.app.databinding.TrackItemBinding;
 
 public class TracksViewHolder extends RecyclerView.ViewHolder {
     private final TrackItemBinding binding;
+    private Pipe<Long> clickAction;
+    private long trackId;
 
     public TracksViewHolder(TrackItemBinding binding) {
         super(binding.getRoot());
         this.binding = binding;
+
+        binding.getRoot().setOnClickListener(view -> {
+            if (clickAction != null)
+                clickAction.push(trackId);
+        });
+    }
+
+    public void setClickAction(Pipe<Long> clickAction) {
+        this.clickAction = clickAction;
     }
 
     public void bind(Track track) {
+        trackId = track.getId();
         binding.setTrack(track);
         binding.executePendingBindings();
     }

--- a/app/src/main/java/org/fossasia/openevent/app/data/db/configuration/OrgaDatabase.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/db/configuration/OrgaDatabase.java
@@ -18,6 +18,7 @@ import org.fossasia.openevent.app.data.event.Event;
 import org.fossasia.openevent.app.data.faq.Faq;
 import org.fossasia.openevent.app.data.feedback.Feedback;
 import org.fossasia.openevent.app.data.order.Order;
+import org.fossasia.openevent.app.data.session.Session;
 import org.fossasia.openevent.app.data.ticket.Ticket;
 import org.fossasia.openevent.app.data.tracks.Track;
 import org.fossasia.openevent.app.data.user.User;
@@ -39,7 +40,7 @@ public final class OrgaDatabase {
     public static final String NAME = "orga_database";
     private static final String DROP_TABLE = "DROP TABLE IF EXISTS ";
     // To be bumped after each schema change and migration addition
-    public static final int VERSION = 11;
+    public static final int VERSION = 12;
 
 
     private OrgaDatabase() {
@@ -177,6 +178,23 @@ public final class OrgaDatabase {
             Timber.d("Running migration for DB version 11");
 
             Class<?>[] recreated = new Class[] {Track.class};
+
+            for (Class<?> recreate: recreated) {
+                ModelAdapter modelAdapter = FlowManager.getModelAdapter(recreate);
+                databaseWrapper.execSQL(DROP_TABLE + modelAdapter.getTableName());
+                databaseWrapper.execSQL(modelAdapter.getCreationQuery());
+            }
+        }
+    }
+
+    @Migration(version = 12, database = OrgaDatabase.class)
+    public static class MigrationTo12 extends BaseMigration {
+
+        @Override
+        public void migrate(@NonNull DatabaseWrapper databaseWrapper) {
+            Timber.d("Running migration for DB version 12");
+
+            Class<?>[] recreated = new Class[] {Session.class};
 
             for (Class<?> recreate: recreated) {
                 ModelAdapter modelAdapter = FlowManager.getModelAdapter(recreate);

--- a/app/src/main/java/org/fossasia/openevent/app/data/session/Session.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/session/Session.java
@@ -1,0 +1,73 @@
+package org.fossasia.openevent.app.data.session;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.github.jasminb.jsonapi.LongIdHandler;
+import com.github.jasminb.jsonapi.annotations.Id;
+import com.github.jasminb.jsonapi.annotations.Relationship;
+import com.github.jasminb.jsonapi.annotations.Type;
+import com.raizlabs.android.dbflow.annotation.ForeignKey;
+import com.raizlabs.android.dbflow.annotation.ForeignKeyAction;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
+
+import org.fossasia.openevent.app.data.db.configuration.OrgaDatabase;
+import org.fossasia.openevent.app.data.event.serializer.ObservableString;
+import org.fossasia.openevent.app.data.event.serializer.ObservableStringDeserializer;
+import org.fossasia.openevent.app.data.event.serializer.ObservableStringSerializer;
+import org.fossasia.openevent.app.data.tracks.Track;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@Builder
+@Type("session")
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString(exclude = "track")
+@JsonNaming(PropertyNamingStrategy.KebabCaseStrategy.class)
+@Table(database = OrgaDatabase.class, allFields = true)
+@EqualsAndHashCode()
+@SuppressWarnings("PMD.TooManyFields")
+public class Session {
+
+    @Id(LongIdHandler.class)
+    @PrimaryKey
+    public Long id;
+
+    @Relationship("track")
+    @ForeignKey(onDelete = ForeignKeyAction.CASCADE)
+    public Track track;
+
+    public String title;
+    public String subtitle;
+    public String level;
+    public String shortAbstract;
+    public String longAbstract;
+    public String comments;
+    public String language;
+    public String slidesUrl;
+    public String videoUrl;
+    public String audioUrl;
+    public String signupUrl;
+    public String state;
+    public String createdAt;
+    public String deletedAt;
+    public String submittedAt;
+    public String lastModifiedAt;
+    public boolean isMailSent;
+
+    @JsonSerialize(using = ObservableStringSerializer.class)
+    @JsonDeserialize(using = ObservableStringDeserializer.class)
+    public ObservableString startsAt = new ObservableString();
+    @JsonSerialize(using = ObservableStringSerializer.class)
+    @JsonDeserialize(using = ObservableStringDeserializer.class)
+    public ObservableString endsAt = new ObservableString();
+}

--- a/app/src/main/java/org/fossasia/openevent/app/data/session/SessionApi.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/session/SessionApi.java
@@ -1,0 +1,13 @@
+package org.fossasia.openevent.app.data.session;
+
+import java.util.List;
+
+import io.reactivex.Observable;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+
+public interface SessionApi {
+
+    @GET("tracks/{id}/sessions?include=track&fields[track]=id&page[size]=0")
+    Observable<List<Session>> getSessions(@Path("id") long id);
+}

--- a/app/src/main/java/org/fossasia/openevent/app/data/session/SessionRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/session/SessionRepository.java
@@ -1,0 +1,8 @@
+package org.fossasia.openevent.app.data.session;
+
+import io.reactivex.Observable;
+
+public interface SessionRepository {
+
+    Observable<Session> getSessions(long id, boolean reload);
+}

--- a/app/src/main/java/org/fossasia/openevent/app/data/session/SessionRepositoryImpl.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/session/SessionRepositoryImpl.java
@@ -1,0 +1,37 @@
+package org.fossasia.openevent.app.data.session;
+
+import org.fossasia.openevent.app.data.Repository;
+
+import javax.inject.Inject;
+
+import io.reactivex.Observable;
+
+public class SessionRepositoryImpl implements SessionRepository {
+
+    private final SessionApi sessionApi;
+    private final Repository repository;
+
+    @Inject
+    public SessionRepositoryImpl(SessionApi sessionApi, Repository repository) {
+        this.sessionApi = sessionApi;
+        this.repository = repository;
+    }
+
+    @Override
+    public Observable<Session> getSessions(long trackId, boolean reload) {
+        Observable<Session> diskObservable = Observable.defer(() ->
+            repository.getItems(Session.class, Session_Table.track_id.eq(trackId))
+        );
+
+        Observable<Session> networkObservable = Observable.defer(() ->
+            sessionApi.getSessions(trackId)
+                .doOnNext(sessions -> repository.syncSave(Session.class, sessions, Session::getId, Session_Table.id).subscribe())
+                .flatMapIterable(sessions -> sessions));
+
+        return repository.observableOf(Session.class)
+            .reload(reload)
+            .withDiskObservable(diskObservable)
+            .withNetworkObservable(networkObservable)
+            .build();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/data/tracks/Track.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/tracks/Track.java
@@ -1,11 +1,13 @@
 package org.fossasia.openevent.app.data.tracks;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.jasminb.jsonapi.LongIdHandler;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.raizlabs.android.dbflow.annotation.ColumnIgnore;
 import com.raizlabs.android.dbflow.annotation.ForeignKey;
 import com.raizlabs.android.dbflow.annotation.ForeignKeyAction;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
@@ -13,6 +15,9 @@ import com.raizlabs.android.dbflow.annotation.Table;
 
 import org.fossasia.openevent.app.data.db.configuration.OrgaDatabase;
 import org.fossasia.openevent.app.data.event.Event;
+import org.fossasia.openevent.app.data.session.Session;
+
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,7 +31,7 @@ import lombok.ToString;
 @Type("track")
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString(exclude = "event")
+@ToString(exclude = {"event", "sessions"})
 @JsonNaming(PropertyNamingStrategy.KebabCaseStrategy.class)
 @Table(database = OrgaDatabase.class, allFields = true)
 @EqualsAndHashCode()
@@ -44,4 +49,9 @@ public class Track {
     @Relationship("event")
     @ForeignKey(stubbedRelationship = true, onDelete = ForeignKeyAction.CASCADE)
     public Event event;
+
+    @ColumnIgnore
+    @Relationship("session")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public List<Session> sessions;
 }

--- a/app/src/main/res/layout/session_layout.xml
+++ b/app/src/main/res/layout/session_layout.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <import type="android.view.View" />
+
+        <import type="org.fossasia.openevent.app.utils.DateUtils" />
+
+        <variable
+            name="session"
+            type="org.fossasia.openevent.app.data.session.Session" />
+    </data>
+
+    <android.support.v7.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/spacing_small">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:baselineAligned="false"
+            android:foreground="?selectableItemBackground"
+            android:gravity="center_vertical">
+
+            <LinearLayout
+                style="@style/ItemPadding"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/spacing_small"
+                    android:text='@{ session.title }'
+                    android:textColor="@android:color/black"
+                    android:textSize="@dimen/text_size_normal"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:drawableLeft="@{ @drawable/ic_info }"
+                    android:drawablePadding="@dimen/spacing_small"
+                    android:drawableStart="@{ @drawable/ic_info }"
+                    android:text='@{ session.subtitle }'
+                    android:textColor="@color/grey_600"
+                    android:textSize="@dimen/text_size_extra_small"
+                    android:visibility="@{ (session.subtitle != null) ? View.VISIBLE : View.GONE }" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:drawableLeft="@{ @drawable/ic_clock }"
+                    android:drawablePadding="@dimen/spacing_small"
+                    android:drawableStart="@{ @drawable/ic_clock }"
+                    android:text='@{ "Starts: " + DateUtils.formatDateWithDefault(DateUtils.FORMAT_DAY_COMPLETE, session.startsAt) }'
+                    android:textColor="@color/grey_600"
+                    android:textSize="@dimen/text_size_extra_small"
+                    android:visibility="@{ (session.startsAt != null) ? View.VISIBLE : View.GONE }" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:drawableLeft="@{ @drawable/ic_clock }"
+                    android:drawablePadding="@dimen/spacing_small"
+                    android:drawableStart="@{ @drawable/ic_clock }"
+                    android:text='@{ "Ends: " + DateUtils.formatDateWithDefault(DateUtils.FORMAT_DAY_COMPLETE, session.endsAt) }'
+                    android:textColor="@color/grey_600"
+                    android:textSize="@dimen/text_size_extra_small"
+                    android:visibility="@{ (session.endsAt != null) ? View.VISIBLE : View.GONE }"/>
+
+            </LinearLayout>
+        </LinearLayout>
+    </android.support.v7.widget.CardView>
+</layout>

--- a/app/src/main/res/layout/sessions_fragment.xml
+++ b/app/src/main/res/layout/sessions_fragment.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <android.support.design.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/color_top_surface">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <android.support.v4.widget.SwipeRefreshLayout
+                android:id="@+id/swipeContainer"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <android.support.v7.widget.RecyclerView
+                    android:id="@+id/sessionsRecyclerView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:clipToPadding="false"
+                    tools:listitem="@layout/session_layout" />
+
+            </android.support.v4.widget.SwipeRefreshLayout>
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/empty_view"
+            android:visibility="gone">
+
+            <include layout="@layout/empty_layout" />
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/progressBar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone">
+
+            <include layout="@layout/progressbar_layout" />
+        </FrameLayout>
+    </android.support.design.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,6 +213,7 @@
     <string name="create_track">Create Track</string>
     <string name="name">Name</string>
     <string name="color">Color</string>
+    <string name="session">Session</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>

--- a/app/src/test/java/org/fossasia/openevent/app/core/presenter/SessionsPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/core/presenter/SessionsPresenterTest.java
@@ -1,0 +1,178 @@
+package org.fossasia.openevent.app.core.presenter;
+
+import org.fossasia.openevent.app.common.rx.Logger;
+import org.fossasia.openevent.app.core.session.list.SessionsPresenter;
+import org.fossasia.openevent.app.core.session.list.SessionsView;
+import org.fossasia.openevent.app.data.db.DatabaseChangeListener;
+import org.fossasia.openevent.app.data.session.Session;
+import org.fossasia.openevent.app.data.session.SessionRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.reactivex.Observable;
+import io.reactivex.android.plugins.RxAndroidPlugins;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(JUnit4.class)
+public class SessionsPresenterTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Mock
+    private SessionsView sessionsView;
+    @Mock
+    private SessionRepository sessionRepository;
+    @Mock
+    private DatabaseChangeListener<Session> databaseChangeListener;
+
+    private SessionsPresenter sessionsPresenter;
+
+    private static final long ID = 10L;
+
+    private static final List<Session> SESSIONS = Arrays.asList(
+        Session.builder().id(2L).title("a").build(),
+        Session.builder().id(3L).title("b").build(),
+        Session.builder().id(4L).title("c").build()
+    );
+
+    @Before
+    public void setUp() {
+        sessionsPresenter = new SessionsPresenter(sessionRepository, databaseChangeListener);
+        sessionsPresenter.attach(ID, sessionsView);
+
+        RxJavaPlugins.setIoSchedulerHandler(scheduler -> Schedulers.trampoline());
+        RxJavaPlugins.setComputationSchedulerHandler(scheduler -> Schedulers.trampoline());
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler(schedulerCallable -> Schedulers.trampoline());
+    }
+
+    @After
+    public void tearDown() {
+        RxJavaPlugins.reset();
+        RxAndroidPlugins.reset();
+    }
+
+    @Test
+    public void shouldLoadSessionListAutomatically() {
+        when(sessionRepository.getSessions(anyLong(), anyBoolean())).thenReturn(Observable.fromIterable(SESSIONS));
+        when(databaseChangeListener.getNotifier()).thenReturn(PublishSubject.create());
+
+        sessionsPresenter.start();
+
+        verify(sessionRepository).getSessions(ID, false);
+    }
+
+    @Test
+    public void shouldShowSessionListAutomatically() {
+        when(sessionRepository.getSessions(ID, false)).thenReturn(Observable.fromIterable(SESSIONS));
+        when(databaseChangeListener.getNotifier()).thenReturn(PublishSubject.create());
+
+        sessionsPresenter.start();
+
+        verify(sessionsView).showResults(SESSIONS);
+    }
+
+    @Test
+    public void shouldActivateChangeListenerOnStart() {
+        when(sessionRepository.getSessions(anyLong(), anyBoolean())).thenReturn(Observable.fromIterable(SESSIONS));
+        when(databaseChangeListener.getNotifier()).thenReturn(PublishSubject.create());
+
+        sessionsPresenter.start();
+
+        verify(databaseChangeListener).startListening();
+    }
+
+    @Test
+    public void shouldDisableChangeListenerOnDetach() {
+        sessionsPresenter.detach();
+
+        verify(databaseChangeListener).stopListening();
+    }
+
+    @Test
+    public void shouldShowEmptyViewOnNoSessionList() {
+        when(sessionRepository.getSessions(anyLong(), anyBoolean())).thenReturn(Observable.fromIterable(new ArrayList<>()));
+
+        sessionsPresenter.loadSessions(true);
+
+        verify(sessionsView).showEmptyView(true);
+    }
+
+    @Test
+    public void shouldShowSessionListOnSwipeRefreshSuccess() {
+        when(sessionRepository.getSessions(ID, true)).thenReturn(Observable.fromIterable(SESSIONS));
+
+        sessionsPresenter.loadSessions(true);
+
+        verify(sessionsView).showResults(any());
+    }
+
+    @Test
+    public void shouldShowErrorMessageOnSwipeRefreshError() {
+        when(sessionRepository.getSessions(ID, true)).thenReturn(Observable.error(Logger.TEST_ERROR));
+
+        sessionsPresenter.loadSessions(true);
+
+        verify(sessionsView).showError(Logger.TEST_ERROR.getMessage());
+    }
+
+    @Test
+    public void testProgressbarOnSwipeRefreshSuccess() {
+        when(sessionRepository.getSessions(ID, true)).thenReturn(Observable.fromIterable(SESSIONS));
+
+        sessionsPresenter.loadSessions(true);
+
+        InOrder inOrder = Mockito.inOrder(sessionsView);
+
+        inOrder.verify(sessionsView).showProgress(true);
+        inOrder.verify(sessionsView).onRefreshComplete(true);
+        inOrder.verify(sessionsView).showProgress(false);
+    }
+
+    @Test
+    public void testProgressbarOnSwipeRefreshError() {
+        when(sessionRepository.getSessions(ID, true)).thenReturn(Observable.error(Logger.TEST_ERROR));
+
+        sessionsPresenter.loadSessions(true);
+
+        InOrder inOrder = Mockito.inOrder(sessionsView);
+
+        inOrder.verify(sessionsView).showProgress(true);
+        inOrder.verify(sessionsView).onRefreshComplete(false);
+        inOrder.verify(sessionsView).showProgress(false);
+    }
+
+    @Test
+    public void testProgressbarOnSwipeRefreshNoItem() {
+        List<Session> emptyList = new ArrayList<>();
+        when(sessionRepository.getSessions(ID, true)).thenReturn(Observable.fromIterable(emptyList));
+
+        sessionsPresenter.loadSessions(true);
+
+        InOrder inOrder = Mockito.inOrder(sessionsView);
+
+        inOrder.verify(sessionsView).showProgress(true);
+        inOrder.verify(sessionsView).onRefreshComplete(true);
+        inOrder.verify(sessionsView).showProgress(false);
+    }
+}

--- a/app/src/test/java/org/fossasia/openevent/app/data/repository/SessionRepositoryTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/data/repository/SessionRepositoryTest.java
@@ -1,0 +1,122 @@
+package org.fossasia.openevent.app.data.repository;
+
+import com.raizlabs.android.dbflow.sql.language.SQLOperator;
+
+import org.fossasia.openevent.app.common.Constants;
+import org.fossasia.openevent.app.data.AbstractObservable;
+import org.fossasia.openevent.app.data.Repository;
+import org.fossasia.openevent.app.data.event.Event;
+import org.fossasia.openevent.app.data.session.Session;
+import org.fossasia.openevent.app.data.session.SessionApi;
+import org.fossasia.openevent.app.data.session.SessionRepositoryImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.reactivex.Completable;
+import io.reactivex.Observable;
+import io.reactivex.android.plugins.RxAndroidPlugins;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SessionRepositoryTest {
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private SessionRepositoryImpl sessionRepository;
+    private static final Session SESSION = new Session();
+    private static final Event EVENT = new Event();
+    private static final long ID = 10L;
+
+    @Mock
+    private SessionApi sessionApi;
+    @Mock private Repository repository;
+
+    static {
+        SESSION.setEvent(EVENT);
+    }
+
+    @Before
+    public void setUp() {
+        when(repository.observableOf(Session.class)).thenReturn(new AbstractObservable.AbstractObservableBuilder<>(repository));
+        sessionRepository = new SessionRepositoryImpl(sessionApi, repository);
+        RxJavaPlugins.setIoSchedulerHandler(scheduler -> Schedulers.trampoline());
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler(schedulerCallable -> Schedulers.trampoline());
+    }
+
+    @After
+    public void tearDown() {
+        RxJavaPlugins.reset();
+        RxAndroidPlugins.reset();
+    }
+
+    @Test
+    public void shouldReturnConnectionErrorOnGetSessionsWithReload() {
+        when(repository.isConnected()).thenReturn(false);
+
+        Observable<Session> sessionObservable = sessionRepository.getSessions(ID, true);
+
+        sessionObservable
+            .test()
+            .assertError(throwable -> throwable.getMessage().equals(Constants.NO_NETWORK));
+    }
+
+    @Test
+    public void shouldReturnConnectionErrorOnGetSessionsWithNoneSaved() {
+        when(repository.isConnected()).thenReturn(false);
+        when(repository.getItems(eq(Session.class), any(SQLOperator.class))).thenReturn(Observable.empty());
+
+        Observable<Session> sessionObservable = sessionRepository.getSessions(ID, false);
+
+        sessionObservable
+            .test()
+            .assertError(throwable -> throwable.getMessage().equals(Constants.NO_NETWORK));
+    }
+
+    @Test
+    public void shouldCallGetSessionsServiceOnReload() {
+        when(repository.isConnected()).thenReturn(true);
+        when(sessionApi.getSessions(ID)).thenReturn(Observable.empty());
+
+        sessionRepository.getSessions(ID, true).subscribe();
+
+        verify(sessionApi).getSessions(ID);
+    }
+
+    @Test
+    public void shouldCallGetSessionsServiceWithNoneSaved() {
+        when(repository.isConnected()).thenReturn(true);
+        when(sessionApi.getSessions(ID)).thenReturn(Observable.empty());
+        when(repository.getItems(eq(Session.class), any(SQLOperator.class))).thenReturn(Observable.empty());
+
+        sessionRepository.getSessions(ID, false).subscribe();
+
+        verify(sessionApi).getSessions(ID);
+    }
+
+    @Test
+    public void shouldSaveSessionsOnGet() {
+        List<Session> sessions = new ArrayList<>();
+        sessions.add(SESSION);
+
+        when(repository.isConnected()).thenReturn(true);
+        when(sessionApi.getSessions(ID)).thenReturn(Observable.just(sessions));
+        when(repository.syncSave(eq(Session.class), eq(sessions), any(), any())).thenReturn(Completable.complete());
+
+        sessionRepository.getSessions(ID, true).subscribe();
+
+        verify(repository).syncSave(eq(Session.class), eq(sessions), any(), any());
+    }
+}

--- a/app/src/test/java/org/fossasia/openevent/app/data/repository/SessionRepositoryTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/data/repository/SessionRepositoryTest.java
@@ -5,10 +5,10 @@ import com.raizlabs.android.dbflow.sql.language.SQLOperator;
 import org.fossasia.openevent.app.common.Constants;
 import org.fossasia.openevent.app.data.AbstractObservable;
 import org.fossasia.openevent.app.data.Repository;
-import org.fossasia.openevent.app.data.event.Event;
 import org.fossasia.openevent.app.data.session.Session;
 import org.fossasia.openevent.app.data.session.SessionApi;
 import org.fossasia.openevent.app.data.session.SessionRepositoryImpl;
+import org.fossasia.openevent.app.data.tracks.Track;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,12 +32,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class SessionRepositoryTest {
+
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     private SessionRepositoryImpl sessionRepository;
     private static final Session SESSION = new Session();
-    private static final Event EVENT = new Event();
+    private static final Track TRACK = new Track();
     private static final long ID = 10L;
 
     @Mock
@@ -45,7 +46,7 @@ public class SessionRepositoryTest {
     @Mock private Repository repository;
 
     static {
-        SESSION.setEvent(EVENT);
+        SESSION.setTrack(TRACK);
     }
 
     @Before


### PR DESCRIPTION
Fixes #902 

Changes: 
1. The user can view list of Sessions associated with event.
2. Save Sessions in database for offline use.
3. Tests are also added.

Screenshots for the change: 
![sesionvd](https://user-images.githubusercontent.com/23634977/39429037-3ba1cb4c-4ca7-11e8-9e0c-ec4b7d5e54f0.gif)

