### PR TITLE
feat: list speakers under an event

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/ApiModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/ApiModule.java
@@ -7,6 +7,7 @@ import org.fossasia.openevent.app.data.event.EventApi;
 import org.fossasia.openevent.app.data.faq.FaqApi;
 import org.fossasia.openevent.app.data.feedback.FeedbackApi;
 import org.fossasia.openevent.app.data.session.SessionApi;
+import org.fossasia.openevent.app.data.speaker.SpeakerApi;
 import org.fossasia.openevent.app.data.sponsor.SponsorApi;
 import org.fossasia.openevent.app.data.ticket.TicketApi;
 import org.fossasia.openevent.app.data.tracks.TrackApi;
@@ -87,4 +88,9 @@ public class ApiModule {
         return retrofit.create(SponsorApi.class);
     }
 
+    @Provides
+    @Singleton
+    SpeakerApi providesSpeakerApi(Retrofit retrofit) {
+        return retrofit.create(SpeakerApi.class);
+    }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/ChangeListenerModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/ChangeListenerModule.java
@@ -6,6 +6,7 @@ import org.fossasia.openevent.app.data.db.DatabaseChangeListener;
 import org.fossasia.openevent.app.data.db.DbFlowDatabaseChangeListener;
 import org.fossasia.openevent.app.data.faq.Faq;
 import org.fossasia.openevent.app.data.session.Session;
+import org.fossasia.openevent.app.data.speaker.Speaker;
 import org.fossasia.openevent.app.data.sponsor.Sponsor;
 import org.fossasia.openevent.app.data.ticket.Ticket;
 import org.fossasia.openevent.app.data.tracks.Track;
@@ -51,4 +52,8 @@ public class ChangeListenerModule {
         return new DbFlowDatabaseChangeListener<>(Sponsor.class);
     }
 
+    @Provides
+    DatabaseChangeListener<Speaker> providesSpeakerChangeListener() {
+        return new DbFlowDatabaseChangeListener<>(Speaker.class);
+    }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/NetworkModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/NetworkModule.java
@@ -8,9 +8,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.jasminb.jsonapi.retrofit.JSONAPIConverterFactory;
 
 import org.fossasia.openevent.app.OrgaProvider;
-import org.fossasia.openevent.app.data.session.Session;
-import org.fossasia.openevent.app.data.sponsor.Sponsor;
-import org.fossasia.openevent.app.data.user.User;
 import org.fossasia.openevent.app.common.Constants;
 import org.fossasia.openevent.app.data.attendee.Attendee;
 import org.fossasia.openevent.app.data.auth.AuthHolder;
@@ -20,8 +17,12 @@ import org.fossasia.openevent.app.data.event.EventStatistics;
 import org.fossasia.openevent.app.data.faq.Faq;
 import org.fossasia.openevent.app.data.feedback.Feedback;
 import org.fossasia.openevent.app.data.network.HostSelectionInterceptor;
+import org.fossasia.openevent.app.data.session.Session;
+import org.fossasia.openevent.app.data.speaker.Speaker;
+import org.fossasia.openevent.app.data.sponsor.Sponsor;
 import org.fossasia.openevent.app.data.ticket.Ticket;
 import org.fossasia.openevent.app.data.tracks.Track;
+import org.fossasia.openevent.app.data.user.User;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -58,7 +59,8 @@ public class NetworkModule {
     @Provides
     Class[] providesMappedClasses() {
         return new Class[]{Event.class, Attendee.class, Ticket.class, User.class,
-            EventStatistics.class, Faq.class, Copyright.class, Feedback.class, Track.class, Session.class, Sponsor.class};
+            EventStatistics.class, Faq.class, Copyright.class, Feedback.class, Track.class,
+                Session.class, Sponsor.class, Speaker.class};
     }
 
     @Provides

--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/RepoModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/RepoModule.java
@@ -14,6 +14,8 @@ import org.fossasia.openevent.app.data.feedback.FeedbackRepository;
 import org.fossasia.openevent.app.data.feedback.FeedbackRepositoryImpl;
 import org.fossasia.openevent.app.data.session.SessionRepository;
 import org.fossasia.openevent.app.data.session.SessionRepositoryImpl;
+import org.fossasia.openevent.app.data.speaker.SpeakerRepository;
+import org.fossasia.openevent.app.data.speaker.SpeakerRepositoryImpl;
 import org.fossasia.openevent.app.data.sponsor.SponsorRepository;
 import org.fossasia.openevent.app.data.sponsor.SponsorRepositoryImpl;
 import org.fossasia.openevent.app.data.ticket.TicketRepository;
@@ -74,4 +76,8 @@ public abstract class RepoModule {
     @Binds
     @Singleton
     abstract SponsorRepository bindsSponsorRepository(SponsorRepositoryImpl sponsorRepositoryImpl);
+
+    @Binds
+    @Singleton
+    abstract SpeakerRepository bindsSpeakerRepository(SpeakerRepositoryImpl speakerRepository);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/android/MainFragmentBuildersModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/android/MainFragmentBuildersModule.java
@@ -8,6 +8,7 @@ import org.fossasia.openevent.app.core.faq.create.CreateFaqFragment;
 import org.fossasia.openevent.app.core.faq.list.FaqListFragment;
 import org.fossasia.openevent.app.core.feedback.list.FeedbackListFragment;
 import org.fossasia.openevent.app.core.settings.SettingsFragment;
+import org.fossasia.openevent.app.core.speaker.list.SpeakersFragment;
 import org.fossasia.openevent.app.core.sponsor.list.SponsorsFragment;
 import org.fossasia.openevent.app.core.ticket.create.CreateTicketFragment;
 import org.fossasia.openevent.app.core.ticket.detail.TicketDetailFragment;
@@ -68,5 +69,10 @@ public abstract class MainFragmentBuildersModule {
     @ContributesAndroidInjector
     abstract SponsorsFragment contributeSponsorsFragment();
 
+
+    // Speaker
+
+    @ContributesAndroidInjector
+    abstract SpeakersFragment contributeSpeakersFragment();
 }
 

--- a/app/src/main/java/org/fossasia/openevent/app/core/main/FragmentNavigator.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/main/FragmentNavigator.java
@@ -11,6 +11,7 @@ import org.fossasia.openevent.app.core.event.list.EventListFragment;
 import org.fossasia.openevent.app.core.faq.list.FaqListFragment;
 import org.fossasia.openevent.app.core.feedback.list.FeedbackListFragment;
 import org.fossasia.openevent.app.core.settings.SettingsFragment;
+import org.fossasia.openevent.app.core.speaker.list.SpeakersFragment;
 import org.fossasia.openevent.app.core.sponsor.list.SponsorsFragment;
 import org.fossasia.openevent.app.core.ticket.list.TicketsFragment;
 import org.fossasia.openevent.app.core.track.list.TracksFragment;
@@ -81,6 +82,9 @@ class FragmentNavigator {
                 break;
             case R.id.nav_sponsor:
                 fragment = SponsorsFragment.newInstance(eventId);
+                break;
+            case R.id.nav_speaker:
+                fragment = SpeakersFragment.newInstance(eventId);
                 break;
             default:
                 fragment = EventDashboardFragment.newInstance(eventId);

--- a/app/src/main/java/org/fossasia/openevent/app/core/speaker/list/SpeakersAdapter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speaker/list/SpeakersAdapter.java
@@ -1,0 +1,39 @@
+package org.fossasia.openevent.app.core.speaker.list;
+
+import android.databinding.DataBindingUtil;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import org.fossasia.openevent.app.R;
+import org.fossasia.openevent.app.core.speaker.list.viewholder.SpeakerViewHolder;
+import org.fossasia.openevent.app.data.speaker.Speaker;
+
+import java.util.List;
+
+public class SpeakersAdapter extends RecyclerView.Adapter<SpeakerViewHolder> {
+    private final List<Speaker> speakers;
+
+    public SpeakersAdapter(SpeakersPresenter speakersPresenter) {
+        this.speakers = speakersPresenter.getSpeakers();
+    }
+
+    @NonNull
+    @Override
+    public SpeakerViewHolder onCreateViewHolder(@NonNull ViewGroup viewGroup, int position) {
+        return new SpeakerViewHolder(
+            DataBindingUtil.inflate(LayoutInflater.from(viewGroup.getContext()),
+                R.layout.speaker_item, viewGroup, false));
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull SpeakerViewHolder speakerViewHolder, int position) {
+        speakerViewHolder.bind(speakers.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return speakers.size();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/speaker/list/SpeakersFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speaker/list/SpeakersFragment.java
@@ -1,0 +1,143 @@
+package org.fossasia.openevent.app.core.speaker.list;
+
+import android.content.Context;
+import android.databinding.DataBindingUtil;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.widget.DefaultItemAnimator;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.fossasia.openevent.app.R;
+import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
+import org.fossasia.openevent.app.core.main.MainActivity;
+import org.fossasia.openevent.app.data.speaker.Speaker;
+import org.fossasia.openevent.app.databinding.SpeakersFragmentBinding;
+import org.fossasia.openevent.app.ui.ViewUtils;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import dagger.Lazy;
+
+public class SpeakersFragment extends BaseFragment<SpeakersPresenter> implements SpeakersView  {
+    private Context context;
+    private long eventId;
+
+    @Inject
+    Lazy<SpeakersPresenter> speakersPresenter;
+
+    private SpeakersAdapter speakersAdapter;
+    private SpeakersFragmentBinding binding;
+    private SwipeRefreshLayout refreshLayout;
+
+    private boolean initialized;
+
+    public static SpeakersFragment newInstance(long eventId) {
+        SpeakersFragment fragment = new SpeakersFragment();
+        Bundle args = new Bundle();
+        args.putLong(MainActivity.EVENT_KEY, eventId);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        context = getContext();
+        if (getArguments() != null)
+            eventId = getArguments().getLong(MainActivity.EVENT_KEY);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        binding = DataBindingUtil.inflate(inflater, R.layout.speakers_fragment, container, false);
+
+        binding.createSpeakerFab.setOnClickListener(view -> {
+            // create Speaker
+        });
+
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        setupRecyclerView();
+        setupRefreshListener();
+        getPresenter().attach(eventId, this);
+        getPresenter().start();
+
+        initialized = true;
+    }
+
+    @Override
+    protected int getTitle() {
+        return R.string.speakers;
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        refreshLayout.setOnRefreshListener(null);
+    }
+
+    private void setupRecyclerView() {
+        if (!initialized) {
+            speakersAdapter = new SpeakersAdapter(getPresenter());
+
+            RecyclerView recyclerView = binding.speakersRecyclerView;
+            recyclerView.setLayoutManager(new LinearLayoutManager(context));
+            recyclerView.setAdapter(speakersAdapter);
+            recyclerView.setItemAnimator(new DefaultItemAnimator());
+        }
+    }
+
+    private void setupRefreshListener() {
+        refreshLayout = binding.swipeContainer;
+        refreshLayout.setColorSchemeColors(getResources().getColor(R.color.color_accent));
+        refreshLayout.setOnRefreshListener(() -> {
+            refreshLayout.setRefreshing(false);
+            getPresenter().loadSpeakers(true);
+        });
+    }
+
+    @Override
+    public void showError(String error) {
+        ViewUtils.showSnackbar(binding.getRoot(), error);
+    }
+
+    @Override
+    public void showProgress(boolean show) {
+        ViewUtils.showView(binding.progressBar, show);
+    }
+
+    @Override
+    public void onRefreshComplete(boolean success) {
+        if (success)
+            ViewUtils.showSnackbar(binding.speakersRecyclerView, R.string.refresh_complete);
+    }
+
+    @Override
+    public void showResults(List<Speaker> items) {
+        speakersAdapter.notifyDataSetChanged();
+    }
+
+    @Override
+    public void showEmptyView(boolean show) {
+        ViewUtils.showView(binding.emptyView, show);
+    }
+
+    @Override
+    protected Lazy<SpeakersPresenter> getPresenterProvider() {
+        return speakersPresenter;
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/speaker/list/SpeakersPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speaker/list/SpeakersPresenter.java
@@ -1,0 +1,78 @@
+package org.fossasia.openevent.app.core.speaker.list;
+
+import com.raizlabs.android.dbflow.structure.BaseModel;
+
+import org.fossasia.openevent.app.common.mvp.presenter.AbstractDetailPresenter;
+import org.fossasia.openevent.app.common.rx.Logger;
+import org.fossasia.openevent.app.data.db.DatabaseChangeListener;
+import org.fossasia.openevent.app.data.db.DbFlowDatabaseChangeListener;
+import org.fossasia.openevent.app.data.speaker.Speaker;
+import org.fossasia.openevent.app.data.speaker.SpeakerRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import io.reactivex.Observable;
+import io.reactivex.schedulers.Schedulers;
+
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.dispose;
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.emptiable;
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.progressiveErroneousRefresh;
+
+public class SpeakersPresenter extends AbstractDetailPresenter<Long, SpeakersView> {
+
+    private final List<Speaker> speakers = new ArrayList<>();
+    private final SpeakerRepository speakerRepository;
+    private final DatabaseChangeListener<Speaker> speakersChangeListener;
+
+    @Inject
+    public SpeakersPresenter(SpeakerRepository speakerRepository, DatabaseChangeListener<Speaker> speakersChangeListener) {
+        this.speakerRepository = speakerRepository;
+        this.speakersChangeListener = speakersChangeListener;
+    }
+
+    @Override
+    public void start() {
+        loadSpeakers(false);
+        listenChanges();
+    }
+
+    @Override
+    public void detach() {
+        super.detach();
+        speakersChangeListener.stopListening();
+    }
+
+    public void loadSpeakers(boolean forceReload) {
+        getSpeakerSource(forceReload)
+            .compose(dispose(getDisposable()))
+            .compose(progressiveErroneousRefresh(getView(), forceReload))
+            .toList()
+            .compose(emptiable(getView(), speakers))
+            .subscribe(Logger::logSuccess, Logger::logError);
+    }
+
+    private Observable<Speaker> getSpeakerSource(boolean forceReload) {
+        if (!forceReload && !speakers.isEmpty() && isRotated())
+            return Observable.fromIterable(speakers);
+        else {
+            return speakerRepository.getSpeakers(getId(), forceReload);
+        }
+    }
+
+    private void listenChanges() {
+        speakersChangeListener.startListening();
+        speakersChangeListener.getNotifier()
+            .compose(dispose(getDisposable()))
+            .map(DbFlowDatabaseChangeListener.ModelChange::getAction)
+            .filter(action -> (action.equals(BaseModel.Action.INSERT)))
+            .subscribeOn(Schedulers.io())
+            .subscribe(speakerModelChange -> loadSpeakers(false), Logger::logError);
+    }
+
+    public List<Speaker> getSpeakers() {
+        return speakers;
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/speaker/list/SpeakersView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speaker/list/SpeakersView.java
@@ -1,0 +1,10 @@
+package org.fossasia.openevent.app.core.speaker.list;
+
+import org.fossasia.openevent.app.common.mvp.view.Emptiable;
+import org.fossasia.openevent.app.common.mvp.view.Erroneous;
+import org.fossasia.openevent.app.common.mvp.view.Progressive;
+import org.fossasia.openevent.app.common.mvp.view.Refreshable;
+import org.fossasia.openevent.app.data.speaker.Speaker;
+
+public interface SpeakersView extends Progressive, Erroneous, Refreshable, Emptiable<Speaker> {
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/speaker/list/viewholder/SpeakerViewHolder.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speaker/list/viewholder/SpeakerViewHolder.java
@@ -1,0 +1,20 @@
+package org.fossasia.openevent.app.core.speaker.list.viewholder;
+
+import android.support.v7.widget.RecyclerView;
+
+import org.fossasia.openevent.app.data.speaker.Speaker;
+import org.fossasia.openevent.app.databinding.SpeakerItemBinding;
+
+public class SpeakerViewHolder extends RecyclerView.ViewHolder {
+    private final SpeakerItemBinding binding;
+
+    public SpeakerViewHolder(SpeakerItemBinding binding) {
+        super(binding.getRoot());
+        this.binding = binding;
+    }
+
+    public void bind(Speaker speaker) {
+        binding.setSpeaker(speaker);
+        binding.executePendingBindings();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/data/db/configuration/OrgaDatabase.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/db/configuration/OrgaDatabase.java
@@ -19,6 +19,7 @@ import org.fossasia.openevent.app.data.faq.Faq;
 import org.fossasia.openevent.app.data.feedback.Feedback;
 import org.fossasia.openevent.app.data.order.Order;
 import org.fossasia.openevent.app.data.session.Session;
+import org.fossasia.openevent.app.data.speaker.Speaker;
 import org.fossasia.openevent.app.data.sponsor.Sponsor;
 import org.fossasia.openevent.app.data.ticket.Ticket;
 import org.fossasia.openevent.app.data.tracks.Track;
@@ -41,7 +42,7 @@ public final class OrgaDatabase {
     public static final String NAME = "orga_database";
     private static final String DROP_TABLE = "DROP TABLE IF EXISTS ";
     // To be bumped after each schema change and migration addition
-    public static final int VERSION = 13;
+    public static final int VERSION = 14;
 
 
     private OrgaDatabase() {
@@ -213,6 +214,23 @@ public final class OrgaDatabase {
             Timber.d("Running migration for DB version 13");
 
             Class<?>[] recreated = new Class[] {Sponsor.class};
+
+            for (Class<?> recreate: recreated) {
+                ModelAdapter modelAdapter = FlowManager.getModelAdapter(recreate);
+                databaseWrapper.execSQL(DROP_TABLE + modelAdapter.getTableName());
+                databaseWrapper.execSQL(modelAdapter.getCreationQuery());
+            }
+        }
+    }
+
+    @Migration(version = 14, database = OrgaDatabase.class)
+    public static class MigrationTo14 extends BaseMigration {
+
+        @Override
+        public void migrate(@NonNull DatabaseWrapper databaseWrapper) {
+            Timber.d("Running migration for DB version 14");
+
+            Class<?>[] recreated = new Class[] {Speaker.class};
 
             for (Class<?> recreate: recreated) {
                 ModelAdapter modelAdapter = FlowManager.getModelAdapter(recreate);

--- a/app/src/main/java/org/fossasia/openevent/app/data/speaker/Speaker.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/speaker/Speaker.java
@@ -1,0 +1,70 @@
+package org.fossasia.openevent.app.data.speaker;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.jasminb.jsonapi.LongIdHandler;
+import com.github.jasminb.jsonapi.annotations.Id;
+import com.github.jasminb.jsonapi.annotations.Relationship;
+import com.github.jasminb.jsonapi.annotations.Type;
+import com.raizlabs.android.dbflow.annotation.ForeignKey;
+import com.raizlabs.android.dbflow.annotation.ForeignKeyAction;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
+
+import org.fossasia.openevent.app.data.db.configuration.OrgaDatabase;
+import org.fossasia.openevent.app.data.event.Event;
+import org.fossasia.openevent.app.data.user.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@Builder
+@Type("speaker")
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString(exclude = {"event", "sessions", "user"})
+@JsonNaming(PropertyNamingStrategy.KebabCaseStrategy.class)
+@Table(database = OrgaDatabase.class, allFields = true)
+@SuppressWarnings("PMD.TooManyFields")
+public class Speaker {
+    @Id(LongIdHandler.class)
+    @PrimaryKey
+    public Long id;
+
+    public String website;
+    public String city;
+    public String shortBiography;
+    public String name;
+    public String speakingExperience;
+    public String country;
+    public String twitter;
+    public String linkedin;
+    public String email;
+    public String longBiography;
+    public String mobile;
+    public String github;
+    public String facebook;
+    public String gender;
+    public String position;
+    public String organisation;
+    public String photoUrl;
+    public String thumbnailImageUrl;
+    public String smallImageUrl;
+    public String iconImageUrl;
+    public String location;
+    public String heardFrom;
+    public String sponsorshipRequired;
+    public boolean isFeatured;
+
+    @Relationship("event")
+    @ForeignKey(stubbedRelationship = true, onDelete = ForeignKeyAction.CASCADE)
+    public Event event;
+
+    @Relationship("user")
+    @ForeignKey(stubbedRelationship = true, onDelete = ForeignKeyAction.CASCADE)
+    public User user;
+}

--- a/app/src/main/java/org/fossasia/openevent/app/data/speaker/SpeakerApi.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/speaker/SpeakerApi.java
@@ -1,0 +1,13 @@
+package org.fossasia.openevent.app.data.speaker;
+
+import java.util.List;
+
+import io.reactivex.Observable;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+
+public interface SpeakerApi {
+
+    @GET("events/{id}/speakers?include=event&fields[event]=id&page[size]=0")
+    Observable<List<Speaker>> getSpeakers(@Path("id") long id);
+}

--- a/app/src/main/java/org/fossasia/openevent/app/data/speaker/SpeakerRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/speaker/SpeakerRepository.java
@@ -1,0 +1,8 @@
+package org.fossasia.openevent.app.data.speaker;
+
+import io.reactivex.Observable;
+
+public interface SpeakerRepository {
+
+    Observable<Speaker> getSpeakers(long id, boolean reload);
+}

--- a/app/src/main/java/org/fossasia/openevent/app/data/speaker/SpeakerRepositoryImpl.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/speaker/SpeakerRepositoryImpl.java
@@ -1,0 +1,37 @@
+package org.fossasia.openevent.app.data.speaker;
+
+import org.fossasia.openevent.app.data.Repository;
+
+import javax.inject.Inject;
+
+import io.reactivex.Observable;
+
+public class SpeakerRepositoryImpl implements SpeakerRepository {
+
+    private final SpeakerApi speakerApi;
+    private final Repository repository;
+
+    @Inject
+    public SpeakerRepositoryImpl(SpeakerApi speakerApi, Repository repository) {
+        this.speakerApi = speakerApi;
+        this.repository = repository;
+    }
+
+    @Override
+    public Observable<Speaker> getSpeakers(long eventId, boolean reload) {
+        Observable<Speaker> diskObservable = Observable.defer(() ->
+            repository.getItems(Speaker.class, Speaker_Table.event_id.eq(eventId))
+        );
+
+        Observable<Speaker> networkObservable = Observable.defer(() ->
+            speakerApi.getSpeakers(eventId)
+                .doOnNext(speakers -> repository.syncSave(Speaker.class, speakers, Speaker::getId, Speaker_Table.id).subscribe())
+                .flatMapIterable(speakers -> speakers));
+
+        return repository.observableOf(Speaker.class)
+            .reload(reload)
+            .withDiskObservable(diskObservable)
+            .withNetworkObservable(networkObservable)
+            .build();
+    }
+}

--- a/app/src/main/res/drawable/ic_people.xml
+++ b/app/src/main/res/drawable/ic_people.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#555"
+        android:pathData="M16,11c1.66,0 2.99,-1.34 2.99,-3S17.66,5 16,5c-1.66,0 -3,1.34 -3,3s1.34,3 3,3zM8,11c1.66,0 2.99,-1.34 2.99,-3S9.66,5 8,5C6.34,5 5,6.34 5,8s1.34,3 3,3zM8,13c-2.33,0 -7,1.17 -7,3.5L1,19h14v-2.5c0,-2.33 -4.67,-3.5 -7,-3.5zM16,13c-0.29,0 -0.62,0.02 -0.97,0.05 1.16,0.84 1.97,1.97 1.97,3.45L17,19h6v-2.5c0,-2.33 -4.67,-3.5 -7,-3.5z"/>
+</vector>

--- a/app/src/main/res/layout/speaker_item.xml
+++ b/app/src/main/res/layout/speaker_item.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="speaker"
+            type="org.fossasia.openevent.app.data.speaker.Speaker" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingBottom="@dimen/spacing_small"
+        android:paddingEnd="@dimen/spacing_normal"
+        android:paddingLeft="@dimen/spacing_small"
+        android:paddingRight="@dimen/spacing_normal"
+        android:paddingStart="@dimen/spacing_small"
+        android:paddingTop="@dimen/spacing_small">
+
+        <ImageView
+            android:layout_width="@dimen/image_small"
+            android:layout_height="@dimen/image_small"
+            android:contentDescription="@string/speakers_photo"
+            app:circleImageUrl="@{ speaker.thumbnailImageUrl }"
+            app:placeholder="@{ @drawable/ic_account_circle }" />
+
+        <TextView
+            android:id="@+id/speakers_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_weight="1"
+            android:paddingBottom="@dimen/spacing_extra_small"
+            android:paddingEnd="@dimen/spacing_small"
+            android:paddingLeft="@dimen/spacing_medium"
+            android:paddingRight="@dimen/spacing_small"
+            android:paddingStart="@dimen/spacing_medium"
+            android:paddingTop="@dimen/spacing_tiny"
+            android:text="@{ speaker.name }"
+            android:textColor="@android:color/black"
+            android:textSize="@dimen/text_size_normal"
+            tools:text="Speaker Name"/>
+
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/speakers_fragment.xml
+++ b/app/src/main/res/layout/speakers_fragment.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <android.support.design.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/color_top_surface">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <android.support.v4.widget.SwipeRefreshLayout
+                android:id="@+id/swipeContainer"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <android.support.v7.widget.RecyclerView
+                    android:id="@+id/speakers_recycler_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:clipToPadding="false"
+                    tools:listitem="@layout/speaker_item" />
+
+            </android.support.v4.widget.SwipeRefreshLayout>
+
+        </FrameLayout>
+
+        <android.support.design.widget.FloatingActionButton
+            android:id="@+id/createSpeakerFab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/spacing_normal"
+            android:layout_marginEnd="@dimen/spacing_normal"
+            android:layout_marginRight="@dimen/spacing_normal"
+            app:fabSize="normal"
+            app:layout_anchor="@id/speakers_recycler_view"
+            app:layout_anchorGravity="bottom|right"
+            app:srcCompat="@drawable/ic_add" />
+
+        <FrameLayout
+            android:id="@+id/empty_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone">
+
+            <include layout="@layout/empty_layout" />
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/progressBar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone">
+
+            <include layout="@layout/progressbar_layout" />
+        </FrameLayout>
+    </android.support.design.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -42,6 +42,10 @@
             android:icon="@drawable/ic_sponsors"
             android:title="@string/sponsors"/>
 
+        <item
+            android:id="@+id/nav_speaker"
+            android:icon="@drawable/ic_people"
+            android:title="@string/speakers"/>
     </group>
 
     <group android:id="@+id/eventsMenu" android:checkableBehavior="single">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,6 +230,7 @@
     <string name="subtitle">Subtitle</string>
     <string name="title">Title</string>
     <string name="session_abstract">Abstract</string>
+    <string name="speakers_photo">Speaker\'s Photo</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>


### PR DESCRIPTION
Fixes #647 

Changes: 

- Fetch speakers for an event
- Save in the database
- Migrated the database
- Implemented staggered grid layout similar to the one implemented in the open-event-android project.

GIF for the change: 
![videotogif_2018 05 09_02 20 15](https://user-images.githubusercontent.com/21277837/39782397-af6e3752-532f-11e8-8ff8-a263cf99f6f3.gif)

