### PR TITLE
feat: Add implementation for Sponsor deletion #939

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsFragment.java
@@ -1,5 +1,6 @@
 package org.fossasia.openevent.app.core.sponsor.list;
 
+import android.app.AlertDialog;
 import android.content.Context;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
@@ -33,6 +34,7 @@ public class SponsorsFragment extends BaseFragment<SponsorsPresenter> implements
 
     private Context context;
     private long eventId;
+    private AlertDialog deleteDialog;
 
     @Inject
     ContextUtils utilModel;
@@ -153,8 +155,31 @@ public class SponsorsFragment extends BaseFragment<SponsorsPresenter> implements
     }
 
     @Override
+    public void showSponsorDeleted(String message) {
+        ViewUtils.showSnackbar(binding.getRoot(), message);
+    }
+
+    @Override
     public void openUpdateSponsorFragment(long sponsorId) {
         BottomSheetDialogFragment bottomSheetDialogFragment = UpdateSponsorFragment.newInstance(sponsorId);
         bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
+    }
+
+    @Override
+    public void showAlertDialog(long sponsorId) {
+        if (deleteDialog == null)
+            deleteDialog = new AlertDialog.Builder(context)
+                .setTitle(R.string.delete)
+                .setMessage(String.format(getString(R.string.delete_confirmation_message),
+                    getString(R.string.sponsors)))
+                .setPositiveButton(R.string.ok, (dialog, which) -> {
+                    getPresenter().deleteSponsor(sponsorId);
+                })
+                .setNegativeButton(R.string.cancel, (dialog, which) -> {
+                    dialog.dismiss();
+                })
+                .create();
+
+        deleteDialog.show();
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsListAdapter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsListAdapter.java
@@ -30,6 +30,7 @@ public class SponsorsListAdapter extends RecyclerView.Adapter<SponsorsViewHolder
                 R.layout.sponsor_item, viewGroup, false));
 
         sponsorsViewHolder.setEditAction(sponsorsPresenter::updateSponsor);
+        sponsorsViewHolder.setDeleteAction(sponsorsPresenter::showDeleteAlertDialog);
 
         return sponsorsViewHolder;
     }

--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsPresenter.java
@@ -18,7 +18,9 @@ import io.reactivex.Observable;
 import io.reactivex.schedulers.Schedulers;
 
 import static org.fossasia.openevent.app.common.rx.ViewTransformers.dispose;
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.disposeCompletable;
 import static org.fossasia.openevent.app.common.rx.ViewTransformers.emptiable;
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.progressiveErroneousCompletable;
 import static org.fossasia.openevent.app.common.rx.ViewTransformers.progressiveErroneousRefresh;
 
 public class SponsorsPresenter extends AbstractDetailPresenter<Long, SponsorsView> {
@@ -78,5 +80,21 @@ public class SponsorsPresenter extends AbstractDetailPresenter<Long, SponsorsVie
     public List<Sponsor> getSponsors() {
         return sponsors;
     }
+
+    public void deleteSponsor(Long sponsorId) {
+        sponsorRepository
+            .deleteSponsor(sponsorId)
+            .compose(disposeCompletable(getDisposable()))
+            .compose(progressiveErroneousCompletable(getView()))
+            .subscribe(() -> {
+                getView().showSponsorDeleted("Sponsor Deleted. Refreshing Items");
+                loadSponsors(true);
+            }, Logger::logError);
+    }
+
+    public void showDeleteAlertDialog(Long sponsorId) {
+        getView().showAlertDialog(sponsorId);
+    }
+
 
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsView.java
@@ -10,4 +10,8 @@ public interface SponsorsView extends Progressive, Erroneous, Refreshable, Empti
 
     void openUpdateSponsorFragment(long sponsorId);
 
+    void showAlertDialog(long sponsorId);
+
+    void showSponsorDeleted(String message);
+
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/viewholder/SponsorsViewHolder.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/viewholder/SponsorsViewHolder.java
@@ -13,6 +13,7 @@ public class SponsorsViewHolder extends RecyclerView.ViewHolder {
     private Sponsor sponsor;
 
     private Pipe<Long> editAction;
+    private Pipe<Long> deleteAction;
 
     public SponsorsViewHolder(SponsorItemBinding binding) {
         super(binding.getRoot());
@@ -21,10 +22,18 @@ public class SponsorsViewHolder extends RecyclerView.ViewHolder {
         binding.actionChangeSponsor.setOnClickListener(view -> {
             if (editAction != null) editAction.push(sponsor.getId());
         });
+
+        binding.actionDeleteSponsor.setOnClickListener(view -> {
+            if (deleteAction != null) deleteAction.push(sponsor.getId());
+        });
     }
 
     public void setEditAction(Pipe<Long> editAction) {
         this.editAction = editAction;
+    }
+
+    public void setDeleteAction(Pipe<Long> deleteAction) {
+        this.deleteAction = deleteAction;
     }
 
     public void bindSponsor(Sponsor sponsor) {

--- a/app/src/main/java/org/fossasia/openevent/app/data/sponsor/SponsorApi.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/sponsor/SponsorApi.java
@@ -2,8 +2,10 @@ package org.fossasia.openevent.app.data.sponsor;
 
 import java.util.List;
 
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import retrofit2.http.Body;
+import retrofit2.http.DELETE;
 import retrofit2.http.GET;
 import retrofit2.http.PATCH;
 import retrofit2.http.POST;
@@ -22,4 +24,7 @@ public interface SponsorApi {
 
     @PATCH("sponsors/{sponsor_id}")
     Observable<Sponsor> updateSponsor(@Path("sponsor_id") long id, @Body Sponsor sponsor);
+
+    @DELETE("sponsors/{sponsor_id}")
+    Completable deleteSponsor(@Path("sponsor_id") long id);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/data/sponsor/SponsorRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/sponsor/SponsorRepository.java
@@ -1,5 +1,6 @@
 package org.fossasia.openevent.app.data.sponsor;
 
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 
 public interface SponsorRepository {
@@ -11,5 +12,7 @@ public interface SponsorRepository {
     Observable<Sponsor> createSponsor(Sponsor sponsor);
 
     Observable<Sponsor> updateSponsor(Sponsor sponsor);
+
+    Completable deleteSponsor(long id);
 
 }

--- a/app/src/main/java/org/fossasia/openevent/app/data/sponsor/SponsorRepositoryImpl.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/sponsor/SponsorRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.fossasia.openevent.app.data.Repository;
 
 import javax.inject.Inject;
 
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
@@ -94,6 +95,20 @@ public class SponsorRepositoryImpl implements SponsorRepository {
             .updateSponsor(sponsor.getId(), sponsor)
             .doOnNext(updatedSponsor -> repository
                 .update(Sponsor.class, updatedSponsor)
+                .subscribe())
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread());
+    }
+
+    @Override
+    public Completable deleteSponsor(long id) {
+        if (!repository.isConnected()) {
+            return Completable.error(new Throwable(Constants.NO_NETWORK));
+        }
+
+        return sponsorApi.deleteSponsor(id)
+            .doOnComplete(() -> repository
+                .delete(Sponsor.class, Sponsor_Table.id.eq(id))
                 .subscribe())
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread());

--- a/app/src/main/res/layout/sponsor_item.xml
+++ b/app/src/main/res/layout/sponsor_item.xml
@@ -57,6 +57,15 @@
                     android:contentDescription="@string/edit_sponsor"
                     app:srcCompat="@drawable/ic_edit" />
 
+                <ImageButton
+                    android:id="@+id/action_delete_sponsor"
+                    android:layout_width="@dimen/spacing_larger"
+                    android:layout_height="@dimen/spacing_larger"
+                    android:layout_gravity="top"
+                    android:background="?android:selectableItemBackground"
+                    android:contentDescription="@string/delete_sponsor"
+                    app:srcCompat="@drawable/ic_delete" />
+
             </LinearLayout>
 
             <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -239,6 +239,7 @@
     <string name="session_abstract">Abstract</string>
     <string name="speakers_photo">Speaker\'s Photo</string>
     <string name="edit_sponsor">Edit Sponsor</string>
+    <string name="delete_sponsor">Delete Sponsor</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>


### PR DESCRIPTION
Fixes #939 

Changes: 
Adds a delete icon to sponsor item, which deletes the Sponsor item from the server and the local database upon confirmation

Screenshots for the change: 
![videotogif_2018 05 16_21 28 29](https://user-images.githubusercontent.com/35009811/40128952-a6982fbc-5950-11e8-9f15-2b2253e7711b.gif)
