### PR TITLE
fix: Polish custom Date and Time pickers by extracting common code

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/ui/views/AbstractDateTimePicker.java
+++ b/app/src/main/java/org/fossasia/openevent/app/ui/views/AbstractDateTimePicker.java
@@ -1,0 +1,77 @@
+package org.fossasia.openevent.app.ui.views;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.util.AttributeSet;
+
+import org.fossasia.openevent.app.common.Function;
+import org.fossasia.openevent.app.data.event.serializer.ObservableString;
+import org.fossasia.openevent.app.utils.DateUtils;
+import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeParseException;
+
+import timber.log.Timber;
+
+public abstract class AbstractDateTimePicker extends android.support.v7.widget.AppCompatButton {
+    private final ObservableString value = new ObservableString();
+    private OnDateTimeChangedListener onDateChangedListener;
+
+    public AbstractDateTimePicker(Context context) {
+        super(context);
+        init();
+    }
+
+    public AbstractDateTimePicker(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public AbstractDateTimePicker(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        init();
+    }
+
+    private void init() {
+        LocalDateTime current = LocalDateTime.now();
+        String isoDate = DateUtils.formatDateToIso(current);
+        setValue(isoDate);
+    }
+
+    protected void bindTemporal(String date, String format, Function<ZonedDateTime, AlertDialog> dialogProvider) {
+        if (date == null)
+            return;
+
+        this.setText(DateUtils.formatDateWithDefault(format, date));
+
+        this.setOnClickListener(view -> {
+            ZonedDateTime zonedDateTime = ZonedDateTime.now();
+            try {
+                zonedDateTime = DateUtils.getDate(date);
+            } catch (DateTimeParseException pe) {
+                Timber.e(pe);
+            }
+            dialogProvider.apply(zonedDateTime).show();
+        });
+    }
+
+    public void setOnDateChangedListener(OnDateTimeChangedListener onDateChangedListener) {
+        this.onDateChangedListener = onDateChangedListener;
+    }
+
+    public void setPickedDate(LocalDateTime pickedDate, String format) {
+        String isoDate = DateUtils.formatDateToIso(pickedDate);
+        this.value.set(isoDate);
+        String formattedDate = DateUtils.formatDateWithDefault(format, isoDate);
+        this.setText(formattedDate);
+        if (onDateChangedListener != null) {
+            onDateChangedListener.onDateChanged(value);
+        }
+    }
+
+    public abstract void setValue(String value);
+
+    public ObservableString getValue() {
+        return value;
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/ui/views/DatePicker.java
+++ b/app/src/main/java/org/fossasia/openevent/app/ui/views/DatePicker.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
+import org.fossasia.openevent.app.data.event.serializer.ObservableString;
 import org.fossasia.openevent.app.utils.DateUtils;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
@@ -12,22 +13,20 @@ import org.threeten.bp.LocalDateTime;
 public class DatePicker extends AbstractDateTimePicker {
     public DatePicker(Context context) {
         super(context);
-
     }
 
     public DatePicker(Context context, AttributeSet attrs) {
         super(context, attrs);
-
     }
 
     public DatePicker(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-
     }
 
     public void setValue(String value) {
-        if (getValue().get() == null || !TextUtils.equals(getValue().get(), value)) {
-            getValue().set(value);
+        ObservableString observableValue = getValue();
+        if (observableValue.get() == null || !TextUtils.equals(observableValue.get(), value)) {
+            observableValue.set(value);
             String format = DateUtils.FORMAT_DATE_COMPLETE;
 
             bindTemporal(value, format, zonedDateTime ->

--- a/app/src/main/java/org/fossasia/openevent/app/ui/views/DatePicker.java
+++ b/app/src/main/java/org/fossasia/openevent/app/ui/views/DatePicker.java
@@ -1,80 +1,33 @@
 package org.fossasia.openevent.app.ui.views;
 
-import android.app.AlertDialog;
 import android.app.DatePickerDialog;
 import android.content.Context;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
-import org.fossasia.openevent.app.common.Function;
-import org.fossasia.openevent.app.data.event.serializer.ObservableString;
 import org.fossasia.openevent.app.utils.DateUtils;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.ZonedDateTime;
-import org.threeten.bp.format.DateTimeParseException;
 
-import timber.log.Timber;
-
-public class DatePicker extends android.support.v7.widget.AppCompatButton {
-    private final ObservableString value = new ObservableString();
-    private OnDateChangedListener onDateChangedListener;
-
+public class DatePicker extends AbstractDateTimePicker {
     public DatePicker(Context context) {
         super(context);
-        init();
+
     }
 
     public DatePicker(Context context, AttributeSet attrs) {
         super(context, attrs);
-        init();
+
     }
 
     public DatePicker(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-        init();
-    }
 
-    private void init() {
-        LocalDateTime current = LocalDateTime.now();
-        String isoDate = DateUtils.formatDateToIso(current);
-        setValue(isoDate);
-    }
-
-    private void bindTemporal(String date, String format, Function<ZonedDateTime, AlertDialog> dialogProvider) {
-        if (date == null)
-            return;
-
-        this.setText(DateUtils.formatDateWithDefault(format, date));
-
-        this.setOnClickListener(view -> {
-            ZonedDateTime zonedDateTime = ZonedDateTime.now();
-            try {
-                zonedDateTime = DateUtils.getDate(date);
-            } catch (DateTimeParseException pe) {
-                Timber.e(pe);
-            }
-            dialogProvider.apply(zonedDateTime).show();
-        });
-    }
-
-    private void setPickedDate(LocalDateTime pickedDate, String format) {
-        String isoDate = DateUtils.formatDateToIso(pickedDate);
-        this.value.set(isoDate);
-        String formattedDate = DateUtils.formatDateWithDefault(format, isoDate);
-        this.setText(formattedDate);
-        if (onDateChangedListener != null) {
-            onDateChangedListener.onDateChanged(value);
-        }
-    }
-
-    public ObservableString getValue() {
-        return value;
     }
 
     public void setValue(String value) {
-        if (this.value.get() == null || !TextUtils.equals(this.value.get(), value)) {
-            this.value.set(value);
+        if (getValue().get() == null || !TextUtils.equals(getValue().get(), value)) {
+            getValue().set(value);
             String format = DateUtils.FORMAT_DATE_COMPLETE;
 
             bindTemporal(value, format, zonedDateTime ->
@@ -83,15 +36,5 @@ public class DatePicker extends android.support.v7.widget.AppCompatButton {
                         LocalDateTime.of(LocalDate.of(year, month + 1, dayOfMonth), zonedDateTime.toLocalTime()), format),
                     zonedDateTime.getYear(), zonedDateTime.getMonthValue() - 1, zonedDateTime.getDayOfMonth()));
         }
-    }
-
-    // change listener
-
-    public interface OnDateChangedListener {
-        void onDateChanged(ObservableString newDate);
-    }
-
-    public void setOnDateChangedListener(OnDateChangedListener onDateChangedListener) {
-        this.onDateChangedListener = onDateChangedListener;
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/ui/views/OnDateTimeChangedListener.java
+++ b/app/src/main/java/org/fossasia/openevent/app/ui/views/OnDateTimeChangedListener.java
@@ -1,0 +1,7 @@
+package org.fossasia.openevent.app.ui.views;
+
+import org.fossasia.openevent.app.data.event.serializer.ObservableString;
+
+public interface OnDateTimeChangedListener {
+    void onDateChanged(ObservableString newDate);
+}

--- a/app/src/main/java/org/fossasia/openevent/app/ui/views/TimePicker.java
+++ b/app/src/main/java/org/fossasia/openevent/app/ui/views/TimePicker.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
+import org.fossasia.openevent.app.data.event.serializer.ObservableString;
 import org.fossasia.openevent.app.utils.DateUtils;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.LocalTime;
@@ -23,8 +24,9 @@ public class TimePicker extends AbstractDateTimePicker {
     }
 
     public void setValue(String value) {
-        if (getValue().get() == null || !TextUtils.equals(getValue().get(), value)) {
-            getValue().set(value);
+        ObservableString observableValue = getValue();
+        if (observableValue.get() == null || !TextUtils.equals(observableValue.get(), value)) {
+            observableValue.set(value);
             String format = DateUtils.FORMAT_24H;
 
             bindTemporal(value, format, zonedDateTime ->

--- a/app/src/main/java/org/fossasia/openevent/app/ui/views/TimePicker.java
+++ b/app/src/main/java/org/fossasia/openevent/app/ui/views/TimePicker.java
@@ -1,80 +1,30 @@
 package org.fossasia.openevent.app.ui.views;
 
-import android.app.AlertDialog;
 import android.app.TimePickerDialog;
 import android.content.Context;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
-import org.fossasia.openevent.app.common.Function;
-import org.fossasia.openevent.app.data.event.serializer.ObservableString;
 import org.fossasia.openevent.app.utils.DateUtils;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.LocalTime;
-import org.threeten.bp.ZonedDateTime;
-import org.threeten.bp.format.DateTimeParseException;
 
-import timber.log.Timber;
-
-public class TimePicker extends android.support.v7.widget.AppCompatButton {
-    private final ObservableString value = new ObservableString();
-    private DatePicker.OnDateChangedListener onDateChangedListener;
-
+public class TimePicker extends AbstractDateTimePicker {
     public TimePicker(Context context) {
         super(context);
-        init();
     }
 
     public TimePicker(Context context, AttributeSet attrs) {
         super(context, attrs);
-        init();
     }
 
     public TimePicker(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-        init();
-    }
-
-    private void init() {
-        LocalDateTime current = LocalDateTime.now();
-        String isoDate = DateUtils.formatDateToIso(current);
-        setValue(isoDate);
-    }
-
-    private void bindTemporal(String date, String format, Function<ZonedDateTime, AlertDialog> dialogProvider) {
-        if (date == null)
-            return;
-
-        this.setText(DateUtils.formatDateWithDefault(format, date));
-
-        this.setOnClickListener(view -> {
-            ZonedDateTime zonedDateTime = ZonedDateTime.now();
-            try {
-                zonedDateTime = DateUtils.getDate(date);
-            } catch (DateTimeParseException pe) {
-                Timber.e(pe);
-            }
-            dialogProvider.apply(zonedDateTime).show();
-        });
-    }
-
-    private void setPickedDate(LocalDateTime pickedDate, String format) {
-        String isoDate = DateUtils.formatDateToIso(pickedDate);
-        this.value.set(isoDate);
-        String formattedDate = DateUtils.formatDateWithDefault(format, isoDate);
-        this.setText(formattedDate);
-        if (onDateChangedListener != null) {
-            onDateChangedListener.onDateChanged(value);
-        }
-    }
-
-    public ObservableString getValue() {
-        return value;
     }
 
     public void setValue(String value) {
-        if (this.value.get() == null || !TextUtils.equals(this.value.get(), value)) {
-            this.value.set(value);
+        if (getValue().get() == null || !TextUtils.equals(getValue().get(), value)) {
+            getValue().set(value);
             String format = DateUtils.FORMAT_24H;
 
             bindTemporal(value, format, zonedDateTime ->
@@ -83,9 +33,5 @@ public class TimePicker extends android.support.v7.widget.AppCompatButton {
                         LocalDateTime.of(zonedDateTime.toLocalDate(), LocalTime.of(hourOfDay, minute)), format),
                     zonedDateTime.getHour(), zonedDateTime.getMinute(), true));
         }
-    }
-
-    public void setOnDateChangedListener(DatePicker.OnDateChangedListener onDateChangedListener) {
-        this.onDateChangedListener = onDateChangedListener;
     }
 }


### PR DESCRIPTION
Fixes #946 

Changes: Extracted out the common code in an ```AbstractDateTimePicker``` class.
Extracted out the ```DateTimeChangeListener``` to a different file

Screenshots for the change: 
![videotogif_2018 05 17_09 49 54](https://user-images.githubusercontent.com/21277837/40156600-23efea6a-59b8-11e8-8e00-c427f6f0e84a.gif)

