### PR TITLE
feat: Move edit and delete options to toolbar #957

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsFragment.java
@@ -1,16 +1,19 @@
 package org.fossasia.openevent.app.core.sponsor.list;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.BottomSheetDialogFragment;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -33,6 +36,8 @@ import dagger.Lazy;
 public class SponsorsFragment extends BaseFragment<SponsorsPresenter> implements SponsorsView {
 
     private Context context;
+    private boolean toolbarEdit;
+    private boolean toolbarDelete;
     private long eventId;
     private AlertDialog deleteDialog;
 
@@ -61,6 +66,8 @@ public class SponsorsFragment extends BaseFragment<SponsorsPresenter> implements
         super.onCreate(savedInstanceState);
 
         context = getContext();
+        setHasOptionsMenu(true);
+
         if (getArguments() != null)
             eventId = getArguments().getLong(MainActivity.EVENT_KEY);
     }
@@ -69,7 +76,10 @@ public class SponsorsFragment extends BaseFragment<SponsorsPresenter> implements
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         binding = DataBindingUtil.inflate(inflater, R.layout.sponsors_fragment, container, false);
-        binding.createSponsorFab.setOnClickListener(view -> openCreateSponsorFragment());
+        binding.createSponsorFab.setOnClickListener(view -> {
+
+            openCreateSponsorFragment();
+        });
         return binding.getRoot();
     }
 
@@ -124,6 +134,60 @@ public class SponsorsFragment extends BaseFragment<SponsorsPresenter> implements
     }
 
     @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.del:
+                showDeleteDialog();
+                break;
+            case R.id.edit:
+                getPresenter().updateSponsor();
+                break;
+            default:
+                // No implementation
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MenuItem menuItemEdit = menu.findItem(R.id.edit);
+        MenuItem menuItemDelete = menu.findItem(R.id.del);
+        menuItemEdit.setVisible(toolbarEdit);
+        menuItemDelete.setVisible(toolbarDelete);
+    }
+
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.menu_sponsors, menu);
+        super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    @Override
+    public void showDeleteDialog() {
+        if (deleteDialog == null)
+            deleteDialog = new AlertDialog.Builder(context)
+                .setTitle(R.string.delete)
+                .setMessage(String.format(getString(R.string.delete_confirmation_message),
+                    getString(R.string.sponsors)))
+                .setPositiveButton(R.string.ok, (dialog, which) -> {
+                    getPresenter().deleteSelectedSponsors();
+                })
+                .setNegativeButton(R.string.cancel, (dialog, which) -> {
+                    dialog.dismiss();
+                })
+                .create();
+
+        deleteDialog.show();
+    }
+
+    @Override
+    public void changeToolbarMode(boolean toolbarEdit, boolean toolbarDelete) {
+        this.toolbarEdit = toolbarEdit;
+        this.toolbarDelete = toolbarDelete;
+        getActivity().invalidateOptionsMenu();
+    }
+
+    @Override
     public Lazy<SponsorsPresenter> getPresenterProvider() {
         return sponsorsPresenter;
     }
@@ -155,7 +219,7 @@ public class SponsorsFragment extends BaseFragment<SponsorsPresenter> implements
     }
 
     @Override
-    public void showSponsorDeleted(String message) {
+    public void showMessage(String message) {
         ViewUtils.showSnackbar(binding.getRoot(), message);
     }
 
@@ -163,23 +227,5 @@ public class SponsorsFragment extends BaseFragment<SponsorsPresenter> implements
     public void openUpdateSponsorFragment(long sponsorId) {
         BottomSheetDialogFragment bottomSheetDialogFragment = UpdateSponsorFragment.newInstance(sponsorId);
         bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
-    }
-
-    @Override
-    public void showAlertDialog(long sponsorId) {
-        if (deleteDialog == null)
-            deleteDialog = new AlertDialog.Builder(context)
-                .setTitle(R.string.delete)
-                .setMessage(String.format(getString(R.string.delete_confirmation_message),
-                    getString(R.string.sponsors)))
-                .setPositiveButton(R.string.ok, (dialog, which) -> {
-                    getPresenter().deleteSponsor(sponsorId);
-                })
-                .setNegativeButton(R.string.cancel, (dialog, which) -> {
-                    dialog.dismiss();
-                })
-                .create();
-
-        deleteDialog.show();
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsListAdapter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsListAdapter.java
@@ -27,10 +27,10 @@ public class SponsorsListAdapter extends RecyclerView.Adapter<SponsorsViewHolder
     public SponsorsViewHolder onCreateViewHolder(@NonNull ViewGroup viewGroup, int position) {
         SponsorsViewHolder sponsorsViewHolder = new SponsorsViewHolder(
             DataBindingUtil.inflate(LayoutInflater.from(viewGroup.getContext()),
-                R.layout.sponsor_item, viewGroup, false));
+                R.layout.sponsor_item, viewGroup, false), sponsorsPresenter);
 
-        sponsorsViewHolder.setEditAction(sponsorsPresenter::updateSponsor);
-        sponsorsViewHolder.setDeleteAction(sponsorsPresenter::showDeleteAlertDialog);
+        sponsorsViewHolder.setLongClickAction(sponsorsPresenter::longClick);
+        sponsorsViewHolder.setClickAction(sponsorsPresenter::click);
 
         return sponsorsViewHolder;
     }

--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsPresenter.java
@@ -1,5 +1,7 @@
 package org.fossasia.openevent.app.core.sponsor.list;
 
+import android.databinding.ObservableBoolean;
+
 import com.raizlabs.android.dbflow.structure.BaseModel;
 
 import org.fossasia.openevent.app.common.mvp.presenter.AbstractDetailPresenter;
@@ -10,7 +12,9 @@ import org.fossasia.openevent.app.data.sponsor.Sponsor;
 import org.fossasia.openevent.app.data.sponsor.SponsorRepository;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -20,7 +24,7 @@ import io.reactivex.schedulers.Schedulers;
 import static org.fossasia.openevent.app.common.rx.ViewTransformers.dispose;
 import static org.fossasia.openevent.app.common.rx.ViewTransformers.disposeCompletable;
 import static org.fossasia.openevent.app.common.rx.ViewTransformers.emptiable;
-import static org.fossasia.openevent.app.common.rx.ViewTransformers.progressiveErroneousCompletable;
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.progressiveErroneous;
 import static org.fossasia.openevent.app.common.rx.ViewTransformers.progressiveErroneousRefresh;
 
 public class SponsorsPresenter extends AbstractDetailPresenter<Long, SponsorsView> {
@@ -28,6 +32,10 @@ public class SponsorsPresenter extends AbstractDetailPresenter<Long, SponsorsVie
     private final List<Sponsor> sponsors = new ArrayList<>();
     private final SponsorRepository sponsorRepository;
     private final DatabaseChangeListener<Sponsor> sponsorChangeListener;
+    private final Map<Long, ObservableBoolean> selectedSponsors = new HashMap<>();
+    private boolean isToolbarActive;
+
+    private static final int EDITABLE_AT_ONCE = 1;
 
     @Inject
     public SponsorsPresenter(SponsorRepository sponsorRepository, DatabaseChangeListener<Sponsor> sponsorChangeListener) {
@@ -47,8 +55,15 @@ public class SponsorsPresenter extends AbstractDetailPresenter<Long, SponsorsVie
         sponsorChangeListener.stopListening();
     }
 
-    public void updateSponsor(Long sponsorId) {
-        getView().openUpdateSponsorFragment(sponsorId);
+    public void updateSponsor() {
+        for (Long id : selectedSponsors.keySet()) {
+            if (selectedSponsors.get(id).get()) {
+                getView().openUpdateSponsorFragment(id);
+                selectedSponsors.get(id).set(false);
+                resetToolbarDefaultState();
+                return;
+            }
+        }
     }
 
     private void listenChanges() {
@@ -56,7 +71,8 @@ public class SponsorsPresenter extends AbstractDetailPresenter<Long, SponsorsVie
         sponsorChangeListener.getNotifier()
             .compose(dispose(getDisposable()))
             .map(DbFlowDatabaseChangeListener.ModelChange::getAction)
-            .filter(action -> action.equals(BaseModel.Action.INSERT) || action.equals(BaseModel.Action.UPDATE))
+            .filter(action -> action.equals(BaseModel.Action.INSERT) || action.equals(BaseModel.Action.UPDATE) ||
+                action.equals(BaseModel.Action.DELETE))
             .subscribeOn(Schedulers.io())
             .subscribe(sponsorModelChange -> loadSponsors(false), Logger::logError);
     }
@@ -81,20 +97,79 @@ public class SponsorsPresenter extends AbstractDetailPresenter<Long, SponsorsVie
         return sponsors;
     }
 
-    public void deleteSponsor(Long sponsorId) {
+    private void deleteSponsor(Long sponsorId) {
         sponsorRepository
             .deleteSponsor(sponsorId)
             .compose(disposeCompletable(getDisposable()))
-            .compose(progressiveErroneousCompletable(getView()))
             .subscribe(() -> {
-                getView().showSponsorDeleted("Sponsor Deleted. Refreshing Items");
-                loadSponsors(true);
+                selectedSponsors.remove(sponsorId);
+                Logger.logSuccess(sponsorId);
             }, Logger::logError);
     }
 
-    public void showDeleteAlertDialog(Long sponsorId) {
-        getView().showAlertDialog(sponsorId);
+    public void deleteSelectedSponsors() {
+        Observable.fromIterable(selectedSponsors.entrySet())
+            .compose(dispose(getDisposable()))
+            .compose(progressiveErroneous(getView()))
+            .doFinally(() -> {
+                getView().showMessage("Sponsors Deleted");
+                resetToolbarDefaultState();
+            })
+            .subscribe(entry -> {
+                if (entry.getValue().get()) {
+                    deleteSponsor(entry.getKey());
+                }
+            }, Logger::logError);
     }
 
+    public void longClick(Sponsor clickedSponsor) {
+        if (isToolbarActive)
+            click(clickedSponsor.getId());
+        else {
+            selectedSponsors.get(clickedSponsor.getId()).set(true);
+            isToolbarActive = true;
+            getView().changeToolbarMode(true, true);
+        }
+    }
+
+    public void click(Long clickedSponsorId) {
+        if (isToolbarActive) {
+
+            if (countSelected() == 1 && isSponsorSelected(clickedSponsorId).get()) {
+                selectedSponsors.get(clickedSponsorId).set(false);
+                resetToolbarDefaultState();
+            } else if (countSelected() == 2 && isSponsorSelected(clickedSponsorId).get()) {
+                selectedSponsors.get(clickedSponsorId).set(false);
+                getView().changeToolbarMode(true, true);
+            } else if (isSponsorSelected(clickedSponsorId).get())
+                selectedSponsors.get(clickedSponsorId).set(false);
+            else
+                selectedSponsors.get(clickedSponsorId).set(true);
+
+            if (countSelected() > EDITABLE_AT_ONCE)
+                getView().changeToolbarMode(false, true);
+        }
+    }
+
+    public void resetToolbarDefaultState() {
+        isToolbarActive = false;
+        getView().changeToolbarMode(false, false);
+    }
+
+    public ObservableBoolean isSponsorSelected(Long sponsorId) {
+        if (!selectedSponsors.containsKey(sponsorId))
+            selectedSponsors.put(sponsorId, new ObservableBoolean(false));
+
+        return selectedSponsors.get(sponsorId);
+    }
+
+    private int countSelected() {
+        int count = 0;
+        for (Long id : selectedSponsors.keySet()) {
+            if (selectedSponsors.get(id).get())
+                count++;
+        }
+        return count;
+    }
 
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/SponsorsView.java
@@ -10,8 +10,10 @@ public interface SponsorsView extends Progressive, Erroneous, Refreshable, Empti
 
     void openUpdateSponsorFragment(long sponsorId);
 
-    void showAlertDialog(long sponsorId);
+    void showDeleteDialog();
 
-    void showSponsorDeleted(String message);
+    void showMessage(String message);
+
+    void changeToolbarMode(boolean toolbarEdit, boolean toolbarDelete);
 
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/viewholder/SponsorsViewHolder.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/list/viewholder/SponsorsViewHolder.java
@@ -4,6 +4,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
 import org.fossasia.openevent.app.common.Pipe;
+import org.fossasia.openevent.app.core.sponsor.list.SponsorsPresenter;
 import org.fossasia.openevent.app.data.sponsor.Sponsor;
 import org.fossasia.openevent.app.databinding.SponsorItemBinding;
 
@@ -11,34 +12,40 @@ public class SponsorsViewHolder extends RecyclerView.ViewHolder {
 
     private final SponsorItemBinding binding;
     private Sponsor sponsor;
+    private SponsorsPresenter sponsorsPresenter;
 
-    private Pipe<Long> editAction;
-    private Pipe<Long> deleteAction;
+    private Pipe<Sponsor> longClickAction;
+    private Pipe<Long> clickAction;
 
-    public SponsorsViewHolder(SponsorItemBinding binding) {
+    public SponsorsViewHolder(SponsorItemBinding binding, SponsorsPresenter sponsorsPresenter) {
         super(binding.getRoot());
         this.binding = binding;
+        this.sponsorsPresenter = sponsorsPresenter;
 
-        binding.actionChangeSponsor.setOnClickListener(view -> {
-            if (editAction != null) editAction.push(sponsor.getId());
+        binding.getRoot().setOnLongClickListener(view -> {
+            if (longClickAction != null) {
+                longClickAction.push(sponsor);
+            }
+            return true;
         });
-
-        binding.actionDeleteSponsor.setOnClickListener(view -> {
-            if (deleteAction != null) deleteAction.push(sponsor.getId());
+        binding.getRoot().setOnClickListener(view -> {
+            if (clickAction != null)
+                clickAction.push(sponsor.getId());
         });
     }
 
-    public void setEditAction(Pipe<Long> editAction) {
-        this.editAction = editAction;
+    public void setLongClickAction(Pipe<Sponsor> longClickAction) {
+        this.longClickAction = longClickAction;
     }
 
-    public void setDeleteAction(Pipe<Long> deleteAction) {
-        this.deleteAction = deleteAction;
+    public void setClickAction(Pipe<Long> clickAction) {
+        this.clickAction = clickAction;
     }
 
     public void bindSponsor(Sponsor sponsor) {
         this.sponsor = sponsor;
         binding.setSponsor(sponsor);
+        binding.setSponsorsPresenter(sponsorsPresenter);
         binding.executePendingBindings();
     }
 

--- a/app/src/main/java/org/fossasia/openevent/app/data/sponsor/Sponsor.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/sponsor/Sponsor.java
@@ -17,14 +17,12 @@ import org.fossasia.openevent.app.data.event.Event;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 @Data
 @Builder
 @Type("sponsor")
 @AllArgsConstructor
 @JsonNaming(PropertyNamingStrategy.KebabCaseStrategy.class)
-@EqualsAndHashCode(callSuper = false, exclude = { "sponsorDelegate", "checking" })
 @Table(database = OrgaDatabase.class, allFields = true)
 public class Sponsor {
 

--- a/app/src/main/res/layout/sponsor_item.xml
+++ b/app/src/main/res/layout/sponsor_item.xml
@@ -7,11 +7,13 @@
 
         <import type="android.view.View" />
 
-        <import type="org.fossasia.openevent.app.core.sponsor.list.SponsorsPresenter"/>
-
         <variable
             name="sponsor"
             type="org.fossasia.openevent.app.data.sponsor.Sponsor" />
+
+        <variable
+            name="sponsorsPresenter"
+            type="org.fossasia.openevent.app.core.sponsor.list.SponsorsPresenter"/>
     </data>
 
     <android.support.v7.widget.CardView
@@ -26,7 +28,9 @@
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
             android:orientation="vertical"
-            android:padding="@dimen/spacing_normal">
+            android:padding="@dimen/spacing_normal"
+            android:background="@{ sponsorsPresenter.isSponsorSelected(sponsor.getId()) ? @color/blue_200 : 0 }"
+            android:foreground="?attr/selectableItemBackground">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -47,24 +51,6 @@
                     style="@style/TextAppearance.AppCompat.Headline"
                     tools:text="Sponsor Name"
                     android:layout_weight="1"/>
-
-                <ImageButton
-                    android:id="@+id/action_change_sponsor"
-                    android:layout_width="@dimen/spacing_larger"
-                    android:layout_height="@dimen/spacing_larger"
-                    android:layout_gravity="top"
-                    android:background="?android:selectableItemBackground"
-                    android:contentDescription="@string/edit_sponsor"
-                    app:srcCompat="@drawable/ic_edit" />
-
-                <ImageButton
-                    android:id="@+id/action_delete_sponsor"
-                    android:layout_width="@dimen/spacing_larger"
-                    android:layout_height="@dimen/spacing_larger"
-                    android:layout_gravity="top"
-                    android:background="?android:selectableItemBackground"
-                    android:contentDescription="@string/delete_sponsor"
-                    app:srcCompat="@drawable/ic_delete" />
 
             </LinearLayout>
 

--- a/app/src/main/res/menu/menu_sponsors.xml
+++ b/app/src/main/res/menu/menu_sponsors.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item android:id="@+id/del"
+        android:title="Delete"
+        android:icon="@drawable/ic_delete"
+        android:visible="false"
+        app:showAsAction="ifRoom">
+    </item>
+
+    <item android:id="@+id/edit"
+        android:title="Update"
+        android:icon="@drawable/ic_edit"
+        android:visible="false"
+        app:showAsAction="ifRoom">
+    </item>
+
+</menu>


### PR DESCRIPTION
Fixes #957 

Changes: 

1. moves edit and delete options from every item in the list to the toolbar 
2. allows the user to long press an item to edit or delete it
3. supports multiple deletions
4. removes edit option in case of multiple selections
5. re-clicking the last selected item unselects
6. re-clicking the only selected item resets the toolbar

**Gif for the change:**

**Delete Operation:**

![videotogif_2018 05 19_04 42 40](https://user-images.githubusercontent.com/35009811/40261703-d71ff90a-5b1f-11e8-80f1-92d4e0c9c3af.gif)

**Edit operation:**

![videotogif_2018 05 19_04 45 43](https://user-images.githubusercontent.com/35009811/40261717-ecfe30e8-5b1f-11e8-8675-34cf49422bb9.gif)