### PR TITLE
Make typed email persist between different AuthActivity fragments

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/auth/SharedViewModel.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/auth/SharedViewModel.java
@@ -1,0 +1,18 @@
+package org.fossasia.openevent.app.core.auth;
+
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.ViewModel;
+
+public class SharedViewModel extends ViewModel {
+
+    private final MutableLiveData<String> email = new MutableLiveData<>();
+
+    public void setEmail(String email) {
+        this.email.setValue(email);
+    }
+
+    public LiveData<String> getEmail() {
+        return email;
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/auth/forgot/request/ForgotPasswordFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/auth/forgot/request/ForgotPasswordFragment.java
@@ -1,5 +1,6 @@
 package org.fossasia.openevent.app.core.auth.forgot.request;
 
+import android.arch.lifecycle.ViewModelProviders;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -10,6 +11,7 @@ import android.widget.Toast;
 
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
+import org.fossasia.openevent.app.core.auth.SharedViewModel;
 import org.fossasia.openevent.app.core.auth.forgot.submit.ResetPasswordByTokenFragment;
 import org.fossasia.openevent.app.core.auth.login.LoginFragment;
 import org.fossasia.openevent.app.databinding.ForgotPasswordFragmentBinding;
@@ -32,6 +34,7 @@ public class ForgotPasswordFragment extends BaseFragment<ForgotPasswordPresenter
 
     private ForgotPasswordFragmentBinding binding;
     private Validator validator;
+    private SharedViewModel sharedViewModel;
 
     public static ForgotPasswordFragment newInstance() {
         return new ForgotPasswordFragment();
@@ -42,6 +45,8 @@ public class ForgotPasswordFragment extends BaseFragment<ForgotPasswordPresenter
                              Bundle savedInstanceState) {
         binding = DataBindingUtil.inflate(inflater, R.layout.forgot_password_fragment, container, false);
         validator = new Validator(binding);
+        sharedViewModel = ViewModelProviders.of(getActivity()).get(SharedViewModel.class);
+        sharedViewModel.getEmail().observe(this, email -> binding.getForgotEmail().setEmail(email));
         return binding.getRoot();
     }
 
@@ -71,6 +76,7 @@ public class ForgotPasswordFragment extends BaseFragment<ForgotPasswordPresenter
     }
 
     private void openLoginPage() {
+        sharedViewModel.setEmail(binding.getForgotEmail().getEmail());
         getFragmentManager().beginTransaction()
             .setCustomAnimations(android.R.anim.slide_in_left, android.R.anim.slide_out_right)
             .replace(R.id.fragment_container, new LoginFragment())

--- a/app/src/main/java/org/fossasia/openevent/app/core/auth/login/LoginFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/auth/login/LoginFragment.java
@@ -12,6 +12,7 @@ import android.widget.ArrayAdapter;
 
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
+import org.fossasia.openevent.app.core.auth.SharedViewModel;
 import org.fossasia.openevent.app.core.auth.forgot.request.ForgotPasswordFragment;
 import org.fossasia.openevent.app.core.auth.signup.SignUpFragment;
 import org.fossasia.openevent.app.core.main.MainActivity;
@@ -35,6 +36,7 @@ public class LoginFragment extends BaseFragment implements LoginView {
     private LoginViewModel loginFragmentViewModel;
     private LoginFragmentBinding binding;
     private Validator validator;
+    private SharedViewModel sharedViewModel;
 
     public static LoginFragment newInstance() {
         return new LoginFragment();
@@ -45,6 +47,8 @@ public class LoginFragment extends BaseFragment implements LoginView {
                              Bundle savedInstanceState) {
         binding = DataBindingUtil.inflate(inflater, R.layout.login_fragment, container, false);
         loginFragmentViewModel = ViewModelProviders.of(this, viewModelFactory).get(LoginViewModel.class);
+        sharedViewModel = ViewModelProviders.of(getActivity()).get(SharedViewModel.class);
+        sharedViewModel.getEmail().observe(this, email -> binding.getLogin().setEmail(email));
         validator = new Validator(binding);
         return binding.getRoot();
     }
@@ -92,6 +96,7 @@ public class LoginFragment extends BaseFragment implements LoginView {
     }
 
     private void openSignUpPage() {
+        sharedViewModel.setEmail(binding.getLogin().getEmail());
         getFragmentManager().beginTransaction()
             .setCustomAnimations(R.anim.enter_from_left, R.anim.exit_from_right)
             .replace(R.id.fragment_container, new SignUpFragment())
@@ -99,6 +104,7 @@ public class LoginFragment extends BaseFragment implements LoginView {
     }
 
     private void openForgotPasswordPage() {
+        sharedViewModel.setEmail(binding.getLogin().getEmail());
         getFragmentManager().beginTransaction()
             .setCustomAnimations(R.anim.enter_from_left, R.anim.exit_from_right)
             .replace(R.id.fragment_container, new ForgotPasswordFragment())

--- a/app/src/main/java/org/fossasia/openevent/app/core/auth/signup/SignUpFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/auth/signup/SignUpFragment.java
@@ -1,5 +1,6 @@
 package org.fossasia.openevent.app.core.auth.signup;
 
+import android.arch.lifecycle.ViewModelProviders;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -10,6 +11,7 @@ import android.widget.Toast;
 
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
+import org.fossasia.openevent.app.core.auth.SharedViewModel;
 import org.fossasia.openevent.app.core.auth.login.LoginFragment;
 import org.fossasia.openevent.app.data.ContextUtils;
 import org.fossasia.openevent.app.databinding.SignUpFragmentBinding;
@@ -32,6 +34,7 @@ public class SignUpFragment extends BaseFragment<SignUpPresenter> implements Sig
 
     private SignUpFragmentBinding binding;
     private Validator validator;
+    private SharedViewModel sharedViewModel;
 
     public static SignUpFragment newInstance() {
         return new SignUpFragment();
@@ -42,6 +45,8 @@ public class SignUpFragment extends BaseFragment<SignUpPresenter> implements Sig
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         binding = DataBindingUtil.inflate(inflater, R.layout.sign_up_fragment, container, false);
         validator = new Validator(binding);
+        sharedViewModel = ViewModelProviders.of(getActivity()).get(SharedViewModel.class);
+        sharedViewModel.getEmail().observe(this, email -> binding.getUser().setEmail(email));
         return binding.getRoot();
     }
 
@@ -69,6 +74,7 @@ public class SignUpFragment extends BaseFragment<SignUpPresenter> implements Sig
     }
 
     private void openLoginPage() {
+        sharedViewModel.setEmail(binding.getUser().getEmail());
         getFragmentManager().beginTransaction()
             .setCustomAnimations(android.R.anim.slide_in_left, android.R.anim.slide_out_right)
             .replace(R.id.fragment_container, new LoginFragment())


### PR DESCRIPTION
Fixes #979 

Changes: 
1. Typed emails now persist between different screen changes so that the user doesn't need to retype email repeatedly.

Gif for the change: 
![videotogif_2018 05 26_21 02 30](https://user-images.githubusercontent.com/35009811/40577865-45d2ef2e-6129-11e8-9cc9-39d41b9cd0b8.gif)
