### PR TITLE
feat: Set placeholder image for Sponsor

### DIFF
--- a/app/src/main/res/layout/sponsor_item.xml
+++ b/app/src/main/res/layout/sponsor_item.xml
@@ -41,6 +41,7 @@
                     android:layout_width="@dimen/image_small"
                     android:layout_height="@dimen/image_small"
                     android:scaleType="fitXY"
+                    app:placeholder="@{ @drawable/ic_photo_shutter }"
                     app:imageUrl='@{ sponsor.getLogoUrl }'/>
 
                 <TextView


### PR DESCRIPTION
Fixes #1008 .

Changes: Set `ic_photo_shutter.xml` as the placeholder image for Sponsor.

Screenshots for the change: 

![screenshot_20180603-163224](https://user-images.githubusercontent.com/18366144/40885876-510a869e-674c-11e8-9d0d-c028a170c65a.png)

