### PR TITLE
feat: Create Call for Speakers

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/ChangeListenerModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/ChangeListenerModule.java
@@ -7,6 +7,7 @@ import org.fossasia.openevent.app.data.db.DbFlowDatabaseChangeListener;
 import org.fossasia.openevent.app.data.faq.Faq;
 import org.fossasia.openevent.app.data.session.Session;
 import org.fossasia.openevent.app.data.speaker.Speaker;
+import org.fossasia.openevent.app.data.speakerscall.SpeakersCall;
 import org.fossasia.openevent.app.data.sponsor.Sponsor;
 import org.fossasia.openevent.app.data.ticket.Ticket;
 import org.fossasia.openevent.app.data.tracks.Track;
@@ -55,5 +56,10 @@ public class ChangeListenerModule {
     @Provides
     DatabaseChangeListener<Speaker> providesSpeakerChangeListener() {
         return new DbFlowDatabaseChangeListener<>(Speaker.class);
+    }
+
+    @Provides
+    DatabaseChangeListener<SpeakersCall> providesSpeakerCallChangeListener() {
+        return new DbFlowDatabaseChangeListener<>(SpeakersCall.class);
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/ViewModelModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/ViewModelModule.java
@@ -6,6 +6,7 @@ import android.arch.lifecycle.ViewModelProvider;
 import org.fossasia.openevent.app.common.di.OrgaViewModelFactory;
 import org.fossasia.openevent.app.core.auth.login.LoginViewModel;
 import org.fossasia.openevent.app.core.speaker.details.SpeakerDetailsViewModel;
+import org.fossasia.openevent.app.core.speakerscall.create.CreateSpeakersCallViewModel;
 
 import dagger.Binds;
 import dagger.Module;
@@ -23,6 +24,11 @@ public abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(SpeakerDetailsViewModel.class)
     public abstract ViewModel bindSpeakerDetailsViewModel(SpeakerDetailsViewModel speakerDetailsViewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(CreateSpeakersCallViewModel.class)
+    public abstract ViewModel bindCreateSpeakersCallViewModel(CreateSpeakersCallViewModel createSpeakersCallViewModel);
 
     @Binds
     public abstract ViewModelProvider.Factory bindViewModelFactory(OrgaViewModelFactory factory);

--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/android/ActivityBuildersModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/android/ActivityBuildersModule.java
@@ -9,6 +9,7 @@ import org.fossasia.openevent.app.core.main.MainActivity;
 import org.fossasia.openevent.app.core.organizer.detail.OrganizerDetailActivity;
 import org.fossasia.openevent.app.core.speaker.details.SpeakerDetailsActivity;
 import org.fossasia.openevent.app.core.speaker.details.SpeakerDetailsFragment;
+import org.fossasia.openevent.app.core.speakerscall.create.CreateSpeakersCallFragment;
 
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;
@@ -42,5 +43,8 @@ public abstract class ActivityBuildersModule {
 
     @ContributesAndroidInjector
     abstract SpeakerDetailsFragment contributeSpeakerDetailsFragment();
+
+    @ContributesAndroidInjector
+    abstract CreateSpeakersCallFragment contributeCreateSpeakersCallFragment();
 
 }

--- a/app/src/main/java/org/fossasia/openevent/app/common/mvp/view/BaseBottomSheetFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/mvp/view/BaseBottomSheetFragment.java
@@ -16,15 +16,21 @@ public abstract class BaseBottomSheetFragment<P extends BasePresenter> extends B
         OrgaApplication.getRefWatcher(getActivity()).watch(this);
     }
 
-    protected abstract Lazy<P> getPresenterProvider();
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+    protected Lazy<P> getPresenterProvider() {
+        return null;
+    }
 
     protected P getPresenter() {
-        return getPresenterProvider().get();
+        Lazy<P> provider = getPresenterProvider();
+        return (provider != null) ? provider.get() : null;
     }
 
     @Override
     public void onStop() {
         super.onStop();
-        getPresenter().detach();
+        P presenter = getPresenter();
+        if (presenter != null)
+            presenter.detach();
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/main/MainActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/main/MainActivity.java
@@ -5,6 +5,7 @@ import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.NavigationView;
+import android.support.v4.app.Fragment;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
@@ -24,11 +25,18 @@ import org.fossasia.openevent.app.ui.ViewUtils;
 import javax.inject.Inject;
 
 import dagger.Lazy;
+import dagger.android.AndroidInjector;
+import dagger.android.DispatchingAndroidInjector;
+import dagger.android.support.HasSupportFragmentInjector;
 
-public class MainActivity extends BaseInjectActivity<MainPresenter> implements NavigationView.OnNavigationItemSelectedListener, MainView {
+public class MainActivity extends BaseInjectActivity<MainPresenter> implements
+    NavigationView.OnNavigationItemSelectedListener, MainView, HasSupportFragmentInjector {
 
     public static final String EVENT_KEY = "event";
     private long eventId = -1;
+
+    @Inject
+    DispatchingAndroidInjector<Fragment> dispatchingAndroidInjector;
 
     @Inject
     Lazy<MainPresenter> presenterProvider;
@@ -108,6 +116,11 @@ public class MainActivity extends BaseInjectActivity<MainPresenter> implements N
         this.eventId = eventId;
         fragmentNavigator.setEventId(eventId);
         binding.navView.getMenu().setGroupVisible(R.id.subMenu, true);
+    }
+
+    @Override
+    public AndroidInjector<Fragment> supportFragmentInjector() {
+        return dispatchingAndroidInjector;
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/create/CreateSpeakersCallFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/create/CreateSpeakersCallFragment.java
@@ -1,0 +1,101 @@
+package org.fossasia.openevent.app.core.speakerscall.create;
+
+import android.arch.lifecycle.ViewModelProvider;
+import android.arch.lifecycle.ViewModelProviders;
+import android.content.Context;
+import android.databinding.DataBindingUtil;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.fossasia.openevent.app.R;
+import org.fossasia.openevent.app.common.mvp.view.BaseBottomSheetFragment;
+import org.fossasia.openevent.app.core.main.MainActivity;
+import org.fossasia.openevent.app.databinding.SpeakersCallCreateLayoutBinding;
+import org.fossasia.openevent.app.ui.ViewUtils;
+
+import javax.inject.Inject;
+
+import br.com.ilhasoft.support.validation.Validator;
+
+import static org.fossasia.openevent.app.ui.ViewUtils.showView;
+
+public class CreateSpeakersCallFragment extends BaseBottomSheetFragment implements CreateSpeakersCallView {
+
+    @Inject
+    ViewModelProvider.Factory viewModelFactory;
+
+    private CreateSpeakersCallViewModel createSpeakersCallViewModel;
+
+    private SpeakersCallCreateLayoutBinding binding;
+    private Validator validator;
+    private long eventId;
+
+    public static CreateSpeakersCallFragment newInstance(long eventId) {
+        CreateSpeakersCallFragment fragment = new CreateSpeakersCallFragment();
+        Bundle args = new Bundle();
+        args.putLong(MainActivity.EVENT_KEY, eventId);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (getArguments() != null) {
+            eventId = getArguments().getLong(MainActivity.EVENT_KEY);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        final Context contextThemeWrapper = new ContextThemeWrapper(getActivity(), R.style.AppTheme);
+        LayoutInflater localInflater = inflater.cloneInContext(contextThemeWrapper);
+        binding =  DataBindingUtil.inflate(localInflater, R.layout.speakers_call_create_layout, container, false);
+
+        createSpeakersCallViewModel = ViewModelProviders.of(this, viewModelFactory).get(CreateSpeakersCallViewModel.class);
+        validator = new Validator(binding.form);
+
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
+        createSpeakersCallViewModel.initialize();
+        createSpeakersCallViewModel.getProgress().observe(this, this::showProgress);
+        createSpeakersCallViewModel.getError().observe(this, this::showError);
+        createSpeakersCallViewModel.getSuccess().observe(this, this::onSuccess);
+
+        binding.setSpeakersCall(createSpeakersCallViewModel.getSpeakersCall());
+
+        binding.submit.setOnClickListener(view -> {
+            if (!validator.validate())
+                return;
+
+            ViewUtils.hideKeyboard(view);
+            createSpeakersCallViewModel.createSpeakersCall(eventId);
+        });
+    }
+
+    @Override
+    public void showProgress(boolean show) {
+        showView(binding.progressBar, show);
+    }
+
+    @Override
+    public void showError(String error) {
+        ViewUtils.showSnackbar(binding.getRoot(), error);
+    }
+
+    @Override
+    public void onSuccess(String message) {
+        ViewUtils.showSnackbar(binding.getRoot(), message);
+        dismiss();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/create/CreateSpeakersCallView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/create/CreateSpeakersCallView.java
@@ -1,0 +1,10 @@
+package org.fossasia.openevent.app.core.speakerscall.create;
+
+import org.fossasia.openevent.app.common.mvp.view.Erroneous;
+import org.fossasia.openevent.app.common.mvp.view.Progressive;
+import org.fossasia.openevent.app.common.mvp.view.Successful;
+
+public interface CreateSpeakersCallView extends Progressive, Successful, Erroneous {
+
+    void dismiss();
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/create/CreateSpeakersCallViewModel.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/create/CreateSpeakersCallViewModel.java
@@ -1,0 +1,96 @@
+package org.fossasia.openevent.app.core.speakerscall.create;
+
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.ViewModel;
+
+import org.fossasia.openevent.app.data.event.Event;
+import org.fossasia.openevent.app.data.speakerscall.SpeakersCall;
+import org.fossasia.openevent.app.data.speakerscall.SpeakersCallRepository;
+import org.fossasia.openevent.app.utils.DateUtils;
+import org.fossasia.openevent.app.utils.ErrorUtils;
+import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeParseException;
+
+import javax.inject.Inject;
+
+import io.reactivex.disposables.CompositeDisposable;
+
+public class CreateSpeakersCallViewModel extends ViewModel {
+
+    private final SpeakersCallRepository speakersCallRepository;
+    private final SpeakersCall speakersCall = new SpeakersCall();
+    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
+
+    private final MutableLiveData<Boolean> progress = new MutableLiveData<>();
+    private final MutableLiveData<String> error = new MutableLiveData<>();
+    private final MutableLiveData<String> success = new MutableLiveData<>();
+
+    @Inject
+    public CreateSpeakersCallViewModel(SpeakersCallRepository speakersCallRepository) {
+        this.speakersCallRepository = speakersCallRepository;
+    }
+
+    public void createSpeakersCall(long eventId) {
+        if (!verify())
+            return;
+
+        Event event = new Event();
+
+        event.setId(eventId);
+        speakersCall.setEvent(event);
+
+        compositeDisposable.add(speakersCallRepository.createSpeakersCall(speakersCall)
+            .doOnSubscribe(disposable -> progress.setValue(true))
+            .doFinally(() -> progress.setValue(false))
+            .subscribe(var -> success.setValue("Speakers Call Created Successfully"),
+                throwable -> error.setValue(ErrorUtils.getMessage(throwable))));
+    }
+
+    public void initialize() {
+        LocalDateTime current = LocalDateTime.now();
+
+        String isoDate = DateUtils.formatDateToIso(current);
+        speakersCall.setStartsAt(isoDate);
+        speakersCall.setEndsAt(isoDate);
+    }
+
+    private boolean verify() {
+        try {
+            ZonedDateTime start = DateUtils.getDate(speakersCall.getStartsAt());
+            ZonedDateTime end = DateUtils.getDate(speakersCall.getEndsAt());
+
+            if (!end.isAfter(start)) {
+                error.setValue("End time should be after start time");
+                return false;
+            }
+            return true;
+        } catch (DateTimeParseException pe) {
+            error.setValue("Please enter date in correct format");
+            return false;
+        }
+    }
+
+    public LiveData<String> getError() {
+        return error;
+    }
+
+    public LiveData<String> getSuccess() {
+        return success;
+    }
+
+    public LiveData<Boolean> getProgress() {
+        return progress;
+    }
+
+    public SpeakersCall getSpeakersCall() {
+        return speakersCall;
+    }
+
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        compositeDisposable.dispose();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/detail/SpeakersCallFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/detail/SpeakersCallFragment.java
@@ -3,6 +3,7 @@ package org.fossasia.openevent.app.core.speakerscall.detail;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.design.widget.BottomSheetDialogFragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -11,6 +12,7 @@ import android.view.ViewGroup;
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
 import org.fossasia.openevent.app.core.main.MainActivity;
+import org.fossasia.openevent.app.core.speakerscall.create.CreateSpeakersCallFragment;
 import org.fossasia.openevent.app.data.ContextUtils;
 import org.fossasia.openevent.app.data.speakerscall.SpeakersCall;
 import org.fossasia.openevent.app.databinding.SpeakersCallFragmentBinding;
@@ -53,7 +55,10 @@ public class SpeakersCallFragment extends BaseFragment<SpeakersCallPresenter> im
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         binding = DataBindingUtil.inflate(inflater, R.layout.speakers_call_fragment, container, false);
-
+        binding.createSpeakersCallFab.setOnClickListener(view -> {
+            BottomSheetDialogFragment bottomSheetDialogFragment = CreateSpeakersCallFragment.newInstance(eventId);
+            bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
+        });
         return binding.getRoot();
     }
 
@@ -110,9 +115,11 @@ public class SpeakersCallFragment extends BaseFragment<SpeakersCallPresenter> im
     public void showResult(SpeakersCall speakersCall) {
         if (speakersCall == null) {
             ViewUtils.showView(binding.emptyView, true);
+            binding.fabFrame.setVisibility(View.VISIBLE);
             return;
         }
 
+        ViewUtils.showView(binding.emptyView, false);
         binding.setSpeakersCall(speakersCall);
         binding.executePendingBindings();
     }

--- a/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/detail/SpeakersCallPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/detail/SpeakersCallPresenter.java
@@ -1,13 +1,18 @@
 package org.fossasia.openevent.app.core.speakerscall.detail;
 
+import com.raizlabs.android.dbflow.structure.BaseModel;
+
 import org.fossasia.openevent.app.common.mvp.presenter.AbstractDetailPresenter;
 import org.fossasia.openevent.app.common.rx.Logger;
+import org.fossasia.openevent.app.data.db.DatabaseChangeListener;
+import org.fossasia.openevent.app.data.db.DbFlowDatabaseChangeListener;
 import org.fossasia.openevent.app.data.speakerscall.SpeakersCall;
 import org.fossasia.openevent.app.data.speakerscall.SpeakersCallRepository;
 
 import javax.inject.Inject;
 
 import io.reactivex.Observable;
+import io.reactivex.schedulers.Schedulers;
 
 import static org.fossasia.openevent.app.common.rx.ViewTransformers.dispose;
 import static org.fossasia.openevent.app.common.rx.ViewTransformers.progressiveErroneousRefresh;
@@ -16,15 +21,28 @@ public class SpeakersCallPresenter extends AbstractDetailPresenter<Long, Speaker
 
     private SpeakersCall speakersCall;
     private final SpeakersCallRepository speakersCallRepository;
+    private final DatabaseChangeListener<SpeakersCall> speakersCallChangeListener;
 
     @Inject
-    public SpeakersCallPresenter(SpeakersCallRepository speakersCallRepository) {
+    public SpeakersCallPresenter(SpeakersCallRepository speakersCallRepository, DatabaseChangeListener<SpeakersCall> speakersCallChangeListener) {
         this.speakersCallRepository = speakersCallRepository;
+        this.speakersCallChangeListener = speakersCallChangeListener;
     }
 
     @Override
     public void start() {
         loadSpeakersCall(false);
+        listenChanges();
+    }
+
+    private void listenChanges() {
+        speakersCallChangeListener.startListening();
+        speakersCallChangeListener.getNotifier()
+            .compose(dispose(getDisposable()))
+            .map(DbFlowDatabaseChangeListener.ModelChange::getAction)
+            .filter(action -> action.equals(BaseModel.Action.INSERT))
+            .subscribeOn(Schedulers.io())
+            .subscribe(speakersCallModelChange -> loadSpeakersCall(false), Logger::logError);
     }
 
     public void loadSpeakersCall(boolean forceReload) {

--- a/app/src/main/java/org/fossasia/openevent/app/data/speakerscall/SpeakersCallApi.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/speakerscall/SpeakersCallApi.java
@@ -1,11 +1,16 @@
 package org.fossasia.openevent.app.data.speakerscall;
 
 import io.reactivex.Observable;
+import retrofit2.http.Body;
 import retrofit2.http.GET;
+import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 public interface SpeakersCallApi {
 
     @GET("events/{id}/speakers-call?include=event&fields[event]=id&page[size]=0")
     Observable<SpeakersCall> getSpeakersCall(@Path("id") long id);
+
+    @POST("speakers-calls")
+    Observable<SpeakersCall> postSpeakersCall(@Body SpeakersCall speakersCall);
 }

--- a/app/src/main/java/org/fossasia/openevent/app/data/speakerscall/SpeakersCallRepository.java
+++ b/app/src/main/java/org/fossasia/openevent/app/data/speakerscall/SpeakersCallRepository.java
@@ -5,4 +5,6 @@ import io.reactivex.Observable;
 public interface SpeakersCallRepository {
 
     Observable<SpeakersCall> getSpeakersCall(long id, boolean reload);
+
+    Observable<SpeakersCall> createSpeakersCall(SpeakersCall speakersCall);
 }

--- a/app/src/main/res/layout/speakers_call_create_form.xml
+++ b/app/src/main/res/layout/speakers_call_create_form.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:bind="http://schemas.android.com/tools">
+
+    <data>
+        <import type="android.view.View" />
+        <import type="org.fossasia.openevent.app.ui.binding.BindingAdapters" />
+
+        <variable
+            name="speakersCall"
+            type="org.fossasia.openevent.app.data.speakerscall.SpeakersCall" />
+    </data>
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        style="@style/ItemPadding"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingTop="@dimen/const_normal">
+
+        <TextView
+            style="@style/TextAppearance.AppCompat.Headline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginTop="@dimen/spacing_normal"
+            android:layout_marginBottom="@dimen/spacing_large"
+            android:layout_marginEnd="@dimen/spacing_large"
+            android:layout_marginRight="@dimen/spacing_large"
+            android:padding="@dimen/spacing_extra_small"
+            android:text="@string/create_speakers_call" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/spacing_extra_small"
+                app:srcCompat="@drawable/ic_speaker" />
+
+            <android.support.design.widget.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/spacing_extra_small">
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/announcement"
+                    android:text="@={ speakersCall.announcement }"
+                    app:validateEmpty="@{true}" />
+
+            </android.support.design.widget.TextInputLayout>
+        </LinearLayout>
+
+        <include
+            layout="@layout/time_picker"
+            bind:date="@={ speakersCall.startsAt }"
+            bind:label="@{ @string/starts_at }"/>
+
+        <include
+            layout="@layout/time_picker"
+            bind:date="@={ speakersCall.endsAt }"
+            bind:label="@{ @string/ends_at }"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/spacing_extra_small"
+                app:srcCompat="@drawable/ic_info" />
+
+            <android.support.design.widget.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/spacing_extra_small">
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/hash"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/hash"
+                    android:text="@={ speakersCall.hash }" />
+
+            </android.support.design.widget.TextInputLayout>
+        </LinearLayout> <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/spacing_extra_small"
+            app:srcCompat="@drawable/ic_password" />
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/spacing_extra_small">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/privacy"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/privacy"
+                android:text="@={ speakersCall.privacy }" />
+
+        </android.support.design.widget.TextInputLayout>
+    </LinearLayout>
+
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/speakers_call_create_layout.xml
+++ b/app/src/main/res/layout/speakers_call_create_layout.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:bind="http://schemas.android.com/apk/res-auto">
+    <data>
+        <import type="android.view.View" />
+
+        <variable
+            name="speakersCall"
+            type="org.fossasia.openevent.app.data.speakerscall.SpeakersCall" />
+    </data>
+
+    <android.support.design.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/color_top_surface">
+
+        <android.support.v4.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <include
+                android:id="@+id/form"
+                bind:speakersCall="@{speakersCall}"
+                layout="@layout/speakers_call_create_form" />
+        </android.support.v4.widget.NestedScrollView>
+
+        <FrameLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|end"
+            android:layout_marginRight="@dimen/spacing_normal"
+            android:layout_marginEnd="@dimen/spacing_normal"
+            android:layout_marginTop="@dimen/spacing_normal">
+
+            <android.support.design.widget.FloatingActionButton
+                android:id="@+id/submit"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                app:backgroundTint="@color/light_green_500"
+                app:fabSize="normal"
+                app:srcCompat="@drawable/ic_check"
+                app:tint="@android:color/white" />
+
+            <FrameLayout
+                android:layout_width="@dimen/progressbar_large"
+                android:layout_height="@dimen/progressbar_large"
+                android:layout_gravity="center">
+
+                <ProgressBar
+                    android:id="@+id/progressBar"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="center"
+                    android:theme="@style/AppTheme"
+                    android:visibility="gone" />
+
+            </FrameLayout>
+
+        </FrameLayout>
+    </android.support.design.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/layout/speakers_call_fragment.xml
+++ b/app/src/main/res/layout/speakers_call_fragment.xml
@@ -32,6 +32,7 @@
                     android:id="@+id/refresh_frame"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
+                    android:visibility="@{ (speakersCall != null) ? View.VISIBLE : View.GONE}"
                     android:divider="?android:dividerHorizontal"
                     android:showDividers="end"
                     android:layout_marginTop="@dimen/spacing_large">
@@ -168,6 +169,27 @@
                 </FrameLayout>
             </android.support.v4.widget.SwipeRefreshLayout>
 
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/fab_frame"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:visibility="gone"
+            android:elevation="1dp"
+            android:layout_marginEnd="@dimen/spacing_normal"
+            android:layout_marginRight="@dimen/spacing_normal"
+            android:layout_marginBottom="@dimen/spacing_normal">
+
+            <android.support.design.widget.FloatingActionButton
+                android:id="@+id/createSpeakersCallFab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                app:fabSize="normal"
+                app:srcCompat="@drawable/ic_add"
+                app:tint="@android:color/white" />
         </FrameLayout>
 
         <FrameLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,6 +257,9 @@
     <string name="github_icon">Github Icon</string>
     <string name="domain_icon">Domain Icon</string>
     <string name="speaker_details_activity">Speaker Details Activity</string>
+    <string name="create_speakers_call">Create Speakers Call</string>
+    <string name="privacy">Privacy</string>
+    <string name="hash">Hash</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>


### PR DESCRIPTION
Fixes #1029 

Changes: 
1. Organizer can create speakers call for event if it does not already exist.
2. Database change listener reflects result in UI without explicitly refreshing.

Screenshots for the change: 
![20180609143518-7c011ad592 gif-2-mp4 com](https://user-images.githubusercontent.com/23634977/41191090-d4dadb6c-6c07-11e8-829f-670fd1987074.gif)
