### PR TITLE
fix: Renamed Base URL to Other URL

### DIFF
--- a/app/src/main/res/layout/auth_url_container.xml
+++ b/app/src/main/res/layout/auth_url_container.xml
@@ -41,7 +41,7 @@
                 android:id="@+id/baseUrl"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/base_url"
+                android:hint="@string/other_url"
                 android:inputType="textUri"
                 android:imeOptions="actionGo"
                 app:go="@{() -> action.run() }"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,6 +257,7 @@
     <string name="github_icon">Github Icon</string>
     <string name="domain_icon">Domain Icon</string>
     <string name="speaker_details_activity">Speaker Details Activity</string>
+    <string name="other_url">Other URL</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>


### PR DESCRIPTION
Fixes #1047 

Changes: 
1. Renamed Base URL to Other URL thus making it user understandable.

Screenshots for the change: 
