### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
Fixes possible gradle build dependency resolve issue on latest Android Studio.

Changes: 
Change google() repository & jcenter() repository access priority so that the gradle build would not fail to resolve dependencies as per latest Android Studio update.

Reference: https://stackoverflow.com/questions/50584437/android-studio-3-1-2-failed-to-resolve-runtime/50758769
