### PR TITLE
Open tickets-sold summary on long pressing Event list item

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/android/MainFragmentBuildersModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/android/MainFragmentBuildersModule.java
@@ -4,6 +4,7 @@ import org.fossasia.openevent.app.core.attendee.checkin.AttendeeCheckInFragment;
 import org.fossasia.openevent.app.core.attendee.list.AttendeesFragment;
 import org.fossasia.openevent.app.core.event.dashboard.EventDashboardFragment;
 import org.fossasia.openevent.app.core.event.list.EventListFragment;
+import org.fossasia.openevent.app.core.event.list.SalesSummaryFragment;
 import org.fossasia.openevent.app.core.faq.create.CreateFaqFragment;
 import org.fossasia.openevent.app.core.faq.list.FaqListFragment;
 import org.fossasia.openevent.app.core.feedback.list.FeedbackListFragment;
@@ -32,6 +33,9 @@ public abstract class MainFragmentBuildersModule {
 
     @ContributesAndroidInjector
     abstract EventListFragment contributeEventListFragment();
+
+    @ContributesAndroidInjector
+    abstract SalesSummaryFragment contributeSalesSummaryFragment();
 
     // Attendee
 

--- a/app/src/main/java/org/fossasia/openevent/app/common/mvp/view/BaseDialogFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/mvp/view/BaseDialogFragment.java
@@ -1,0 +1,37 @@
+package org.fossasia.openevent.app.common.mvp.view;
+
+import android.support.v4.app.DialogFragment;
+
+import org.fossasia.openevent.app.OrgaApplication;
+import org.fossasia.openevent.app.common.di.Injectable;
+import org.fossasia.openevent.app.common.mvp.presenter.BasePresenter;
+
+import dagger.Lazy;
+
+public class BaseDialogFragment<P extends BasePresenter> extends DialogFragment implements Injectable {
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        OrgaApplication.getRefWatcher(getActivity()).watch(this);
+    }
+
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+    protected Lazy<P> getPresenterProvider() {
+        return null;
+    }
+
+    protected P getPresenter() {
+        Lazy<P> provider = getPresenterProvider();
+        return (provider != null) ? provider.get() : null;
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        P presenter = getPresenter();
+        if (presenter != null)
+            presenter.detach();
+    }
+}
+

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/list/EventListFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/list/EventListFragment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.DefaultItemAnimator;
@@ -64,7 +65,6 @@ public class EventListFragment extends BaseFragment<EventsPresenter> implements 
 
     private Context context;
     private boolean initialized;
-    private boolean editMode;
     private long id;
 
     /**
@@ -85,7 +85,6 @@ public class EventListFragment extends BaseFragment<EventsPresenter> implements 
         super.onCreate(savedInstanceState);
         context = getActivity();
         setHasOptionsMenu(true);
-        editMode = false;
     }
 
     @Override
@@ -119,15 +118,6 @@ public class EventListFragment extends BaseFragment<EventsPresenter> implements 
     }
 
     @Override
-    public void onPrepareOptionsMenu(Menu menu) {
-        super.onPrepareOptionsMenu(menu);
-        MenuItem menuItemSort = menu.findItem(R.id.sort);
-        MenuItem menuItemEdit = menu.findItem(R.id.edit);
-        menuItemSort.setVisible(!editMode);
-        menuItemEdit.setVisible(editMode);
-    }
-
-    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.sortByEventName:
@@ -135,11 +125,6 @@ public class EventListFragment extends BaseFragment<EventsPresenter> implements 
                 return true;
             case R.id.sortByEventDate:
                 sortEvents(SORTBYDATE);
-                return true;
-            case R.id.edit:
-                Intent intent = new Intent(getActivity(), CreateEventActivity.class);
-                intent.putExtra(CreateEventActivity.EVENT_ID, id);
-                startActivity(intent);
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
@@ -231,7 +216,6 @@ public class EventListFragment extends BaseFragment<EventsPresenter> implements 
     public void onRefreshComplete(boolean success) {
         if (success) {
             ViewUtils.showSnackbar(recyclerView, R.string.refresh_complete);
-            getPresenter().resetToDefaultState();
         }
     }
 
@@ -253,21 +237,21 @@ public class EventListFragment extends BaseFragment<EventsPresenter> implements 
     }
 
     @Override
-    public void changeToEditMode(long id) {
-        editMode = true;
-        this.id = id;
-        getActivity().invalidateOptionsMenu();
-    }
-
-    @Override
-    public void changeToNormalMode() {
-        editMode = false;
-        getActivity().invalidateOptionsMenu();
-    }
-
-    @Override
     public void resetEventsList() {
         eventListAdapter.categorizeEvents();
         binding.bottomNavigation.setSelectedItemId(R.id.action_live);
+    }
+
+    @Override
+    public void openSalesSummary(Long eventId) {
+        DialogFragment fragment = SalesSummaryFragment.newInstance(eventId);
+        fragment.show(getFragmentManager(), "summary");
+    }
+
+    @Override
+    public void closeSalesSummary() {
+        DialogFragment fragment = ((DialogFragment) getFragmentManager().findFragmentByTag("summary"));
+        if (fragment != null)
+            fragment.dismiss();
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/list/EventsPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/list/EventsPresenter.java
@@ -1,6 +1,5 @@
 package org.fossasia.openevent.app.core.event.list;
 
-import android.databinding.ObservableBoolean;
 import android.support.annotation.VisibleForTesting;
 
 import org.fossasia.openevent.app.common.mvp.presenter.AbstractBasePresenter;
@@ -12,8 +11,6 @@ import org.fossasia.openevent.app.utils.service.DateService;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.inject.Inject;
 
@@ -26,11 +23,8 @@ import static org.fossasia.openevent.app.common.rx.ViewTransformers.progressiveE
 public class EventsPresenter extends AbstractBasePresenter<EventsView> {
 
     private final List<Event> events = new ArrayList<>();
-    private boolean editMode;
     private final EventRepository eventsDataRepository;
-    private Event lastEvent = new Event();
 
-    public final Map<Event, ObservableBoolean> selectedMap = new ConcurrentHashMap<>();
     public static final int SORTBYDATE = 0;
     public static final int SORTBYNAME = 1;
 
@@ -83,45 +77,16 @@ public class EventsPresenter extends AbstractBasePresenter<EventsView> {
         return super.getView();
     }
 
-    public void unselectEvent(Event event) {
-        if (event != null && selectedMap.containsKey(event))
-            selectedMap.get(event).set(false);
+    public void openSalesSummary(Long eventId) {
+        getView().openSalesSummary(eventId);
     }
 
-    @SuppressWarnings("PMD.DataflowAnomalyAnalysis") // Inevitable DD anomaly
-    public void toolbarEditMode(Event currentEvent) {
-        long id = 0;
-        if (!lastEvent.equals(currentEvent)) {
-            unselectEvent(lastEvent);
-            id = currentEvent.getId();
-        }
-        selectedMap.get(currentEvent).set(true);
-        editMode = true;
-        lastEvent = currentEvent;
-        getView().changeToEditMode(id);
-    }
-
-    public void resetToDefaultState() {
-        unselectEvent(lastEvent);
-        editMode = false;
-        getView().changeToNormalMode();
-    }
-
-    public boolean isEditMode() {
-        return editMode;
-    }
-
-    public ObservableBoolean getEventsSelected(Event event) {
-        if (!selectedMap.containsKey(event)) {
-            selectedMap.put(event, new ObservableBoolean(false));
-        }
-        return selectedMap.get(event);
+    public void closeSalesSummary() {
+        getView().closeSalesSummary();
     }
 
     @Override
     public void detach() {
         super.detach();
-        selectedMap.clear();
-        resetToDefaultState();
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/list/EventsView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/list/EventsView.java
@@ -8,7 +8,7 @@ import org.fossasia.openevent.app.data.event.Event;
 
 public interface EventsView extends Progressive, Erroneous, Refreshable, Emptiable<Event> {
 
-    void changeToEditMode(long id);
-    void changeToNormalMode();
     void resetEventsList();
+    void openSalesSummary(Long id);
+    void closeSalesSummary();
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/list/SalesSummaryFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/list/SalesSummaryFragment.java
@@ -1,0 +1,93 @@
+package org.fossasia.openevent.app.core.event.list;
+
+import android.databinding.DataBindingUtil;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.fossasia.openevent.app.R;
+import org.fossasia.openevent.app.common.mvp.view.BaseDialogFragment;
+import org.fossasia.openevent.app.data.event.Event;
+import org.fossasia.openevent.app.databinding.FragmentSalesSummaryBinding;
+import org.fossasia.openevent.app.ui.ViewUtils;
+
+import javax.inject.Inject;
+
+import dagger.Lazy;
+
+import static org.fossasia.openevent.app.core.event.dashboard.EventDashboardFragment.EVENT_ID;
+
+/**
+ * A simple {@link Fragment} subclass.
+ */
+public class SalesSummaryFragment extends BaseDialogFragment<SalesSummaryPresenter> implements SalesSummaryView {
+
+    private long eventId;
+
+    @Inject
+    Lazy<SalesSummaryPresenter> presenterProvider;
+
+    FragmentSalesSummaryBinding binding;
+
+    public SalesSummaryFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public Lazy<SalesSummaryPresenter> getPresenterProvider() {
+        return presenterProvider;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        getPresenter().attach(eventId, this);
+        getPresenter().start();
+    }
+
+    public static SalesSummaryFragment newInstance(long eventId) {
+        SalesSummaryFragment fragment = new SalesSummaryFragment();
+        Bundle args = new Bundle();
+        args.putLong(EVENT_ID, eventId);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            eventId = arguments.getLong(EVENT_ID);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_sales_summary, container, false);
+        return binding.getRoot();
+    }
+
+    @Override
+    public void showProgress(boolean show) {
+        ViewUtils.showView(binding.progressBar, show);
+    }
+
+    @Override
+    public void showError(String error) {
+        binding.content.setVisibility(View.GONE);
+        ViewUtils.showView(binding.emptyView, true);
+        ViewUtils.showSnackbar(binding.getRoot(), error);
+    }
+
+    @Override
+    public void showResult(Event event) {
+        binding.setEvent(event);
+        binding.executePendingBindings();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/list/SalesSummaryPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/list/SalesSummaryPresenter.java
@@ -1,0 +1,80 @@
+package org.fossasia.openevent.app.core.event.list;
+
+import org.fossasia.openevent.app.common.mvp.presenter.AbstractDetailPresenter;
+import org.fossasia.openevent.app.data.attendee.Attendee;
+
+import org.fossasia.openevent.app.common.rx.Logger;
+import org.fossasia.openevent.app.core.event.dashboard.analyser.TicketAnalyser;
+import org.fossasia.openevent.app.data.attendee.AttendeeRepository;
+import org.fossasia.openevent.app.data.event.Event;
+import org.fossasia.openevent.app.data.event.EventRepository;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import io.reactivex.Observable;
+
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.dispose;
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.progressiveErroneous;
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.result;
+
+
+public class SalesSummaryPresenter extends AbstractDetailPresenter<Long, SalesSummaryView> {
+
+
+    private Event event;
+    private List<Attendee> attendees;
+    private final EventRepository eventRepository;
+    private final AttendeeRepository attendeeRepository;
+    private final TicketAnalyser ticketAnalyser;
+
+    @Inject
+    public SalesSummaryPresenter(EventRepository eventRepository, AttendeeRepository attendeeRepository,
+                                   TicketAnalyser ticketAnalyser) {
+        this.eventRepository = eventRepository;
+        this.ticketAnalyser = ticketAnalyser;
+        this.attendeeRepository = attendeeRepository;
+    }
+
+    @Override
+    public void start() {
+        loadDetails(false);
+    }
+
+    public void loadDetails(boolean forceReload) {
+        if (getView() == null)
+            return;
+
+        getEventSource(forceReload)
+            .compose(dispose(getDisposable()))
+            .compose(result(getView()))
+            .flatMap(loadedEvent -> {
+                this.event = loadedEvent;
+                ticketAnalyser.analyseTotalTickets(event);
+                return getAttendeeSource(forceReload);
+            })
+            .compose(progressiveErroneous(getView()))
+            .toList()
+            .subscribe(attendees -> {
+                this.attendees = attendees;
+                ticketAnalyser.analyseSoldTickets(event, attendees);
+            }, Logger::logError);
+
+    }
+
+    private Observable<Event> getEventSource(boolean forceReload) {
+        if (!forceReload && event != null && isRotated())
+            return Observable.just(event);
+        else
+            return eventRepository.getEvent(getId(), forceReload);
+    }
+
+    private Observable<Attendee> getAttendeeSource(boolean forceReload) {
+        if (!forceReload && attendees != null && isRotated())
+            return Observable.fromIterable(attendees);
+        else
+            return attendeeRepository.getAttendees(getId(), forceReload);
+    }
+
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/list/SalesSummaryView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/list/SalesSummaryView.java
@@ -1,0 +1,9 @@
+package org.fossasia.openevent.app.core.event.list;
+
+import org.fossasia.openevent.app.common.mvp.view.Erroneous;
+import org.fossasia.openevent.app.common.mvp.view.ItemResult;
+import org.fossasia.openevent.app.common.mvp.view.Progressive;
+import org.fossasia.openevent.app.data.event.Event;
+
+public interface SalesSummaryView extends Progressive, Erroneous, ItemResult<Event> {
+}

--- a/app/src/main/res/layout/event_layout.xml
+++ b/app/src/main/res/layout/event_layout.xml
@@ -21,7 +21,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@{ eventsPresenter.getEventsSelected(event) ? @color/blue_200 : (Event.STATE_DRAFT.equalsIgnoreCase(event.state)) ? @color/event_state_draft : android.R.attr.selectableItemBackground}"
+        android:background="@{ (Event.STATE_DRAFT.equalsIgnoreCase(event.state)) ? @color/event_state_draft : android.R.attr.selectableItemBackground }"
         android:orientation="horizontal">
 
         <FrameLayout

--- a/app/src/main/res/layout/fragment_sales_summary.xml
+++ b/app/src/main/res/layout/fragment_sales_summary.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:bind="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="event"
+            type="org.fossasia.openevent.app.data.event.Event" />
+    </data>
+
+    <FrameLayout
+        android:id="@+id/content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="@dimen/spacing_normal"
+        android:elevation="4dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center_horizontal"
+            android:background="@android:color/white">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/tickets_sold"
+                android:gravity="center"
+                android:layout_marginBottom="@dimen/spacing_normal"
+                android:textSize="@dimen/text_size_normal"/>
+
+            <include
+                layout="@layout/ticket_analytics_item"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                bind:color='@{"light_blue"}'
+                bind:completed="@{event.analytics.soldFreeTickets}"
+                bind:ticketName="@{@string/ticket_free}"
+                bind:total="@{event.analytics.freeTickets}" />
+
+            <include
+                layout="@layout/ticket_analytics_item"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                bind:color='@{"purple"}'
+                bind:completed="@{event.analytics.soldPaidTickets}"
+                bind:ticketName="@{@string/ticket_paid}"
+                bind:total="@{event.analytics.paidTickets}" />
+
+            <include
+                layout="@layout/ticket_analytics_item"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                bind:color='@{"red"}'
+                bind:completed="@{event.analytics.soldDonationTickets}"
+                bind:ticketName="@{@string/ticket_donation}"
+                bind:total="@{event.analytics.donationTickets}" />
+        </LinearLayout>
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/emptyView"
+            android:visibility="gone">
+
+            <include layout="@layout/empty_layout" />
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/progressBar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone">
+
+            <include layout="@layout/progressbar_layout" />
+        </FrameLayout>
+
+    </FrameLayout>
+
+</layout>

--- a/app/src/main/res/layout/ticket_analytics.xml
+++ b/app/src/main/res/layout/ticket_analytics.xml
@@ -155,14 +155,15 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/spacing_normal"
+            android:layout_marginLeft="@dimen/spacing_normal"
             android:baselineAligned="false"
-            android:orientation="horizontal">
+            android:orientation="vertical"
+            android:layout_marginStart="@dimen/spacing_normal">
 
             <include
                 layout="@layout/ticket_analytics_item"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
                 bind:color='@{"light_blue"}'
                 bind:completed="@{event.analytics.soldFreeTickets}"
                 bind:ticketName="@{@string/ticket_free}"
@@ -170,9 +171,8 @@
 
             <include
                 layout="@layout/ticket_analytics_item"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
                 bind:color='@{"purple"}'
                 bind:completed="@{event.analytics.soldPaidTickets}"
                 bind:ticketName="@{@string/ticket_paid}"
@@ -180,9 +180,8 @@
 
             <include
                 layout="@layout/ticket_analytics_item"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
                 bind:color='@{"red"}'
                 bind:completed="@{event.analytics.soldDonationTickets}"
                 bind:ticketName="@{@string/ticket_donation}"

--- a/app/src/main/res/layout/ticket_analytics_item.xml
+++ b/app/src/main/res/layout/ticket_analytics_item.xml
@@ -23,19 +23,13 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center"
-            android:orientation="vertical"
+            android:orientation="horizontal"
             android:padding="@dimen/spacing_small">
-
-            <TextView
-                style="@style/TextAppearance.AppCompat.Body2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/spacing_extra_small"
-                android:text="@{ticketName}" />
 
             <FrameLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:layout_gravity="start">
 
                 <com.mikhaellopez.circularprogressbar.CircularProgressBar
                     android:layout_width="@dimen/ticket_progress_size"
@@ -45,17 +39,41 @@
                     app:cpb_progressbar_width="10dp"
                     app:progress_with_animation="@{total == 0 ? 0 : (int) ((completed*100)/total)}" />
 
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="@dimen/text_size_large"
+                    android:textStyle="bold"
+                    android:layout_gravity="center"
+                    android:text='@{(total == 0 ? 0 : (int) ((completed*100)/total)) + "%"}' />
+
+            </FrameLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_gravity="center"
+                android:layout_marginLeft="@dimen/spacing_normal">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/spacing_extra_small"
+                    android:textSize="@dimen/text_size_large"
+                    android:textColor="@android:color/black"
+                    android:text="@{ticketName}" />
+
                 <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center"
                     android:orientation="horizontal">
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@{completed}"
-                        android:textSize="@dimen/text_size_large"
+                        android:textSize="@dimen/text_size_normal"
                         android:textStyle="bold" />
 
                     <TextView
@@ -66,12 +84,6 @@
 
                 </LinearLayout>
 
-            </FrameLayout>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text='@{(total == 0 ? 0 : (int) ((completed*100)/total)) + "%"}' />
-
+            </LinearLayout>
         </LinearLayout>
 </layout>


### PR DESCRIPTION
Fixes #1059 

Changes:
1. Long pressing Event List items shows tickets sold summary
2. Similar layout has replaced the older horizontal view for Dashboard.

Screenshots for the change:
<img src="https://user-images.githubusercontent.com/35009811/41335183-8def897c-6f05-11e8-8c45-d16ab64fe785.png" width="250"/> <img src="https://user-images.githubusercontent.com/35009811/41372727-c493507e-6f6b-11e8-8b91-74cc7a1227d6.png" width="250"/>
