### PR TITLE
chore: Changed the Share fragment title

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/share/ShareEventFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/share/ShareEventFragment.java
@@ -120,7 +120,7 @@ public class ShareEventFragment extends BaseFragment implements ShareEventView {
 
     @Override
     protected int getTitle() {
-        return R.string.speaker_details;
+        return R.string.share;
     }
 
     @Override


### PR DESCRIPTION
Fixes #1066 

Changes: The Share fragment now shows "Share" as the toolbar title.

