### PR TITLE
bug: Event image visible in placeholder

### DIFF
--- a/app/src/main/res/layout/share_event_layout.xml
+++ b/app/src/main/res/layout/share_event_layout.xml
@@ -54,6 +54,7 @@
                             android:contentDescription="@string/event_thumbnail"
                             android:scaleType="fitXY"
                             app:paletteKey='@{ "event_header" }'
+                            app:paletteImageUrl="@{ event.largeImageUrl }"
                             app:placeholder="@{ @drawable/header}" />
 
                         <LinearLayout


### PR DESCRIPTION
Fixes #1075 
Changes: The placeholder in the Share Fragment now shows the event image (if it was set earlier).