### PR TITLE
fix: Close Session layout on creation

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/session/create/CreateSessionFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/session/create/CreateSessionFragment.java
@@ -10,6 +10,7 @@ import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
 import org.fossasia.openevent.app.R;
 import org.fossasia.openevent.app.common.Function;
@@ -173,6 +174,11 @@ public class CreateSessionFragment extends BaseFragment<CreateSessionPresenter> 
 
     @Override
     public void onSuccess(String message) {
-        ViewUtils.showSnackbar(binding.getRoot(), message);
+        Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void dismiss() {
+        getFragmentManager().popBackStack();
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/session/create/CreateSessionPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/session/create/CreateSessionPresenter.java
@@ -93,8 +93,10 @@ public class CreateSessionPresenter extends AbstractBasePresenter<CreateSessionV
             .updateSession(session)
             .compose(dispose(getDisposable()))
             .compose(progressiveErroneous(getView()))
-            .subscribe(updatedSession -> getView().onSuccess("Session Updated Successfully"),
-                Logger::logError);
+            .subscribe(updatedSession -> {
+                    getView().onSuccess("Session Updated Successfully");
+                    getView().dismiss();
+            }, Logger::logError);
     }
 
     public void createSession(long trackId, long eventId) {
@@ -115,6 +117,9 @@ public class CreateSessionPresenter extends AbstractBasePresenter<CreateSessionV
             .createSession(session)
             .compose(dispose(getDisposable()))
             .compose(progressiveErroneous(getView()))
-            .subscribe(createdSession -> getView().onSuccess("Session Created"), Logger::logError);
+            .subscribe(createdSession -> {
+                getView().onSuccess("Session Created");
+                getView().dismiss();
+            }, Logger::logError);
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/session/create/CreateSessionView.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/session/create/CreateSessionView.java
@@ -13,4 +13,6 @@ public interface CreateSessionView extends Progressive, Erroneous, Successful {
     void validate(TextInputLayout textInputLayout, Function<String, Boolean> function, String str);
 
     void setSession(Session session);
+
+    void dismiss();
 }


### PR DESCRIPTION
Fixes #1077 

Changes: 
1. Closing session layout on creation.
2. Closing session layout on update.

Screenshots for the change:

![20180615141427-7c011ad592 gif-2-mp4 com](https://user-images.githubusercontent.com/23634977/41465416-a0906382-70bb-11e8-8873-6bb541b3e5d7.gif)

