### PR TITLE
fix: Nullify Empty Fields in Sponsors

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/create/CreateSponsorPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/create/CreateSponsorPresenter.java
@@ -1,11 +1,14 @@
 package org.fossasia.openevent.app.core.sponsor.create;
 
+import android.support.annotation.VisibleForTesting;
+
 import org.fossasia.openevent.app.common.ContextManager;
 import org.fossasia.openevent.app.common.mvp.presenter.AbstractBasePresenter;
 import org.fossasia.openevent.app.common.rx.Logger;
 import org.fossasia.openevent.app.data.event.Event;
 import org.fossasia.openevent.app.data.sponsor.Sponsor;
 import org.fossasia.openevent.app.data.sponsor.SponsorRepository;
+import org.fossasia.openevent.app.utils.StringUtils;
 
 import javax.inject.Inject;
 
@@ -31,11 +34,21 @@ public class CreateSponsorPresenter extends AbstractBasePresenter<CreateSponsorV
         return sponsor;
     }
 
+    @VisibleForTesting
+    protected void nullifyEmptyFields(Sponsor sponsor) {
+        sponsor.setDescription(StringUtils.emptyToNull(sponsor.getDescription()));
+        sponsor.setLogoUrl(StringUtils.emptyToNull(sponsor.getLogoUrl()));
+        sponsor.setUrl(StringUtils.emptyToNull(sponsor.getUrl()));
+        sponsor.setType(StringUtils.emptyToNull(sponsor.getType()));
+    }
+
     public void createSponsor() {
         long eventId = ContextManager.getSelectedEvent().getId();
         Event event = new Event();
         event.setId(eventId);
         sponsor.setEvent(event);
+
+        nullifyEmptyFields(sponsor);
 
         sponsorRepository
             .createSponsor(sponsor)

--- a/app/src/main/java/org/fossasia/openevent/app/core/sponsor/update/UpdateSponsorPresenter.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/sponsor/update/UpdateSponsorPresenter.java
@@ -1,5 +1,7 @@
 package org.fossasia.openevent.app.core.sponsor.update;
 
+import android.support.annotation.VisibleForTesting;
+
 import org.fossasia.openevent.app.common.ContextManager;
 import org.fossasia.openevent.app.common.mvp.presenter.AbstractBasePresenter;
 import org.fossasia.openevent.app.common.rx.Logger;
@@ -40,8 +42,12 @@ public class UpdateSponsorPresenter extends AbstractBasePresenter<UpdateSponsorV
         getView().setSponsor(sponsor);
     }
 
-    private void nullifyEmptyFields(Sponsor sponsor) {
+    @VisibleForTesting
+    protected void nullifyEmptyFields(Sponsor sponsor) {
         sponsor.setDescription(StringUtils.emptyToNull(sponsor.getDescription()));
+        sponsor.setLogoUrl(StringUtils.emptyToNull(sponsor.getLogoUrl()));
+        sponsor.setUrl(StringUtils.emptyToNull(sponsor.getUrl()));
+        sponsor.setType(StringUtils.emptyToNull(sponsor.getType()));
     }
 
     public void updateSponsor() {


### PR DESCRIPTION
Fixes #1078 

Changes: 
1. Set Empty fields while Sponsors creation to null.
2. Set Empty fields while Sponsors update to null.

