### PR TITLE
feat: Add Device Name preference to Settings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -265,6 +265,8 @@
     <string name="privacy">Privacy</string>
     <string name="hash">Hash</string>
     <string name="other_url">Other URL</string>
+    <string name="device_name">Device Name</string>
+    <string name="device_name_summary">Name your device to track check-ins and sales processed by this device in your Open Event account</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -13,4 +13,9 @@
 
     </android.support.v7.preference.PreferenceCategory>
 
+    <android.support.v7.preference.EditTextPreference
+        android:key="device_name"
+        android:title="Device Name"
+        android:summary="@string/device_name_summary"/>
+
 </android.support.v7.preference.PreferenceScreen>


### PR DESCRIPTION
Fixes #1074 

Changes: Adds Device name preference to Settings

(An extra screen for Device name exists in EventBrite. Please suggest if it needs to be added in Orga App also.)

<img src="https://user-images.githubusercontent.com/35009811/41495847-9df35e84-714e-11e8-89d3-6ca548d04c4b.png" width="250"/>
<img src="https://user-images.githubusercontent.com/35009811/41495873-035d695e-714f-11e8-9208-622e76c15bb9.png" width="250"/> <img src="https://user-images.githubusercontent.com/35009811/41495874-03892350-714f-11e8-94d3-4b9f91468a1a.png" width="250"/>
