### PR TITLE
feat: Add EventViewModel extracting related code from MainPresenter

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/common/di/module/ViewModelModule.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/di/module/ViewModelModule.java
@@ -5,6 +5,7 @@ import android.arch.lifecycle.ViewModelProvider;
 
 import org.fossasia.openevent.app.common.di.OrgaViewModelFactory;
 import org.fossasia.openevent.app.core.auth.login.LoginViewModel;
+import org.fossasia.openevent.app.core.main.EventViewModel;
 import org.fossasia.openevent.app.core.orders.detail.OrderDetailViewModel;
 import org.fossasia.openevent.app.core.main.OrganizerViewModel;
 import org.fossasia.openevent.app.core.orders.list.OrdersViewModel;
@@ -53,6 +54,11 @@ public abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(OrganizerViewModel.class)
     public abstract ViewModel bindOrganizerViewModel(OrganizerViewModel organizerViewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(EventViewModel.class)
+    public abstract ViewModel bindEventViewModel(EventViewModel eventViewModel);
 
     @Binds
     public abstract ViewModelProvider.Factory bindViewModelFactory(OrgaViewModelFactory factory);

--- a/app/src/main/java/org/fossasia/openevent/app/common/livedata/SingleEventLiveData.java
+++ b/app/src/main/java/org/fossasia/openevent/app/common/livedata/SingleEventLiveData.java
@@ -1,0 +1,47 @@
+package org.fossasia.openevent.app.common.livedata;
+
+import android.arch.lifecycle.LifecycleOwner;
+import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.Observer;
+import android.support.annotation.MainThread;
+import android.support.annotation.Nullable;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A wrapper over MutableLiveData in order to send a single event from ViewModel.
+ * @param <T> Data type of the LiveData.
+ */
+public class SingleEventLiveData<T> extends MutableLiveData<T> {
+
+    private final AtomicBoolean pending = new AtomicBoolean(false);
+
+    @MainThread
+    public void observe(LifecycleOwner owner, final Observer<T> observer) {
+
+        if (hasActiveObservers()) {
+            throw new IllegalStateException("Only one observer at a time may subscribe to a SingleEventLiveData");
+        }
+
+        // Observe the internal MutableLiveData
+        super.observe(owner, t -> {
+            if (pending.compareAndSet(true, false)) {
+                observer.onChanged(t);
+            }
+        });
+    }
+
+    @MainThread
+    public void setValue(@Nullable T t) {
+        pending.set(true);
+        super.setValue(t);
+    }
+
+    /**
+     * Used for cases where T is Void, to make calls cleaner.
+     */
+    @MainThread
+    public void call() {
+        setValue(null);
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/main/EventViewModel.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/main/EventViewModel.java
@@ -1,0 +1,121 @@
+package org.fossasia.openevent.app.core.main;
+
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.ViewModel;
+
+import org.fossasia.openevent.app.common.ContextManager;
+import org.fossasia.openevent.app.common.livedata.SingleEventLiveData;
+import org.fossasia.openevent.app.common.rx.Logger;
+import org.fossasia.openevent.app.data.Bus;
+import org.fossasia.openevent.app.data.Preferences;
+import org.fossasia.openevent.app.data.event.Event;
+import org.fossasia.openevent.app.data.event.EventRepository;
+import org.fossasia.openevent.app.utils.CurrencyUtils;
+
+import javax.inject.Inject;
+
+import io.reactivex.disposables.CompositeDisposable;
+
+import static org.fossasia.openevent.app.common.rx.ViewTransformers.dispose;
+import static org.fossasia.openevent.app.core.main.MainActivity.EVENT_KEY;
+
+public class EventViewModel extends ViewModel {
+    private final Preferences sharedPreferenceModel;
+    private final Bus bus;
+    private final CurrencyUtils currencyUtils;
+    private final EventRepository eventRepository;
+    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
+
+    private final MutableLiveData<Long> eventId = new MutableLiveData<>();
+    private final MutableLiveData<String> error = new MutableLiveData<>();
+    private final MutableLiveData<Event> selectedEvent = new MutableLiveData<>();
+    private final SingleEventLiveData<Void> showEventList = new SingleEventLiveData<>();
+    private final SingleEventLiveData<Void> showDashboard = new SingleEventLiveData<>();
+
+    @Inject
+    public EventViewModel(Preferences sharedPreferenceModel, Bus bus,
+                          CurrencyUtils currencyUtils, EventRepository eventRepository) {
+        this.sharedPreferenceModel = sharedPreferenceModel;
+        this.bus = bus;
+        this.currencyUtils = currencyUtils;
+        this.eventRepository = eventRepository;
+
+        onStart();
+    }
+
+    private void onStart() {
+        bus.getSelectedEvent()
+            .compose(dispose(compositeDisposable))
+            .subscribe(event -> {
+                sharedPreferenceModel.setLong(EVENT_KEY, event.getId());
+                ContextManager.setSelectedEvent(event);
+                currencyUtils.getCurrencySymbol(event.getPaymentCurrency())
+                    .subscribe(ContextManager::setCurrency, Logger::logError);
+                showLoadedEvent(event.getId());
+            }, throwable -> {
+                Logger.logError(throwable);
+                error.setValue(throwable.getMessage());
+            });
+
+        long storedEventId = sharedPreferenceModel.getLong(EVENT_KEY, -1);
+
+        if (storedEventId == -1)
+            showEventList();
+        else
+            showLoadedEvent(storedEventId);
+    }
+
+    private void showLoadedEvent(long storedEventId) {
+        eventId.setValue(storedEventId);
+        Event staticEvent = ContextManager.getSelectedEvent();
+
+        if (staticEvent != null) {
+            selectedEvent.setValue(staticEvent);
+            showEventDashboard();
+            return;
+        }
+
+        eventRepository
+            .getEvent(storedEventId, false)
+            .compose(dispose(compositeDisposable))
+            .subscribe(bus::pushSelectedEvent, throwable -> {
+                Logger.logError(throwable);
+                error.setValue(throwable.getMessage());
+            });
+    }
+
+    private void showEventList() {
+        showEventList.call();
+    }
+
+    private void showEventDashboard() {
+        showDashboard.call();
+    }
+
+    protected LiveData<Long> getEventId() {
+        return eventId;
+    }
+
+    protected LiveData<String> getError() {
+        return error;
+    }
+
+    protected LiveData<Event> getSelectedEvent() {
+        return selectedEvent;
+    }
+
+    protected LiveData<Void> getShowEventList() {
+        return showEventList;
+    }
+
+    protected LiveData<Void> getShowDashboard() {
+        return showDashboard;
+    }
+
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        compositeDisposable.dispose();
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/app/core/main/MainActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/main/MainActivity.java
@@ -52,6 +52,7 @@ public class MainActivity extends BaseInjectActivity<MainPresenter> implements
     private MainActivityBinding binding;
     private MainNavHeaderBinding headerBinding;
     private OrganizerViewModel organizerViewModel;
+    private EventViewModel eventViewModel;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -61,6 +62,7 @@ public class MainActivity extends BaseInjectActivity<MainPresenter> implements
         headerBinding = MainNavHeaderBinding.bind(binding.navView.getHeaderView(0));
 
         organizerViewModel = ViewModelProviders.of(this, viewModelFactory).get(OrganizerViewModel.class);
+        eventViewModel = ViewModelProviders.of(this, viewModelFactory).get(EventViewModel.class);
 
         setSupportActionBar(binding.main.toolbar);
 
@@ -85,6 +87,11 @@ public class MainActivity extends BaseInjectActivity<MainPresenter> implements
         getPresenter().start();
 
         organizerViewModel.getOrganizer().observe(this, this::showOrganizer);
+        eventViewModel.getEventId().observe(this, this::setEventId);
+        eventViewModel.getSelectedEvent().observe(this, this::showResult);
+        eventViewModel.getError().observe(this, this::showError);
+        eventViewModel.getShowDashboard().observe(this, aVoid -> this.showDashboard());
+        eventViewModel.getShowEventList().observe(this, aVoid -> this.showEventList());
     }
 
     @Override

--- a/app/src/test/java/org/fossasia/openevent/app/core/presenter/MainPresenterTest.java
+++ b/app/src/test/java/org/fossasia/openevent/app/core/presenter/MainPresenterTest.java
@@ -4,15 +4,9 @@ import com.f2prateek.rx.preferences2.Preference;
 import com.f2prateek.rx.preferences2.RxSharedPreferences;
 
 import org.fossasia.openevent.app.common.ContextManager;
-import org.fossasia.openevent.app.data.auth.AuthService;
-import org.fossasia.openevent.app.data.Bus;
-import org.fossasia.openevent.app.data.Preferences;
-import org.fossasia.openevent.app.data.event.Event;
-import org.fossasia.openevent.app.data.event.EventRepository;
-import org.fossasia.openevent.app.core.main.MainActivity;
 import org.fossasia.openevent.app.core.main.MainPresenter;
 import org.fossasia.openevent.app.core.main.MainView;
-import org.fossasia.openevent.app.utils.CurrencyUtils;
+import org.fossasia.openevent.app.data.auth.AuthService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,10 +16,7 @@ import org.mockito.junit.MockitoRule;
 
 import io.reactivex.Completable;
 import io.reactivex.Observable;
-import io.reactivex.subjects.PublishSubject;
 
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,34 +27,20 @@ public class MainPresenterTest {
     @Mock private AuthService loginModel;
     @Mock private MainView mainView;
     @Mock private ContextManager contextManager;
-    @Mock private CurrencyUtils currencyUtils;
-    @Mock private Bus bus;
     @Mock private Preference<Boolean> booleanPref;
-    @Mock private Preferences sharedPreferenceModel;
     @Mock private RxSharedPreferences rxSharedPreferences;
-    @Mock private EventRepository eventRepository;
-
-    private static final PublishSubject<Event> PUBLISHER = PublishSubject.create();
 
     private MainPresenter mainPresenter;
 
-    private static final long EVENT_ID = 2L;
-    private static final Event EVENT = Event.builder().id(2L).paymentCurrency("INR").build();
-
     @Before
     public void setUp() {
-        mainPresenter = new MainPresenter(sharedPreferenceModel, loginModel, eventRepository, bus,
-            rxSharedPreferences, contextManager, currencyUtils);
+        mainPresenter = new MainPresenter(loginModel, rxSharedPreferences, contextManager);
         mainPresenter.attach(mainView);
     }
 
     private void mockCommons() {
         when(booleanPref.asObservable()).thenReturn(Observable.just(true));
         when(rxSharedPreferences.getBoolean(anyString())).thenReturn(booleanPref);
-
-        when(bus.getSelectedEvent()).thenReturn(PUBLISHER);
-
-        when(eventRepository.getEvent(anyLong(), anyBoolean())).thenReturn(Observable.just(EVENT));
     }
 
     @Test
@@ -79,68 +56,9 @@ public class MainPresenterTest {
     public void shouldInvalidateViewsOnTimezonePrefChange() {
         mockCommons();
 
-        when(sharedPreferenceModel.getLong(anyString(), anyLong())).thenReturn(EVENT_ID);
-
         mainPresenter.start();
 
         verify(mainView).invalidateDateViews();
-    }
-
-    @Test
-    public void shouldSaveEventOnPush() {
-        mockCommons();
-
-        mainPresenter.start();
-        PUBLISHER.onNext(EVENT);
-
-        verify(sharedPreferenceModel).setLong(MainActivity.EVENT_KEY, EVENT_ID);
-    }
-
-    @Test
-    public void shouldShowDashboardOnEventIdStored() {
-        mockCommons();
-
-        when(sharedPreferenceModel.getLong(anyString(), anyLong())).thenReturn(EVENT_ID);
-        ContextManager.setSelectedEvent(EVENT);
-
-        mainPresenter.start();
-
-        verify(mainView).showDashboard();
-    }
-
-    @Test
-    public void shouldLoadEventFromRepoIfNotStored() {
-        mockCommons();
-
-        when(sharedPreferenceModel.getLong(anyString(), anyLong())).thenReturn(EVENT_ID);
-        ContextManager.setSelectedEvent(null);
-
-        mainPresenter.start();
-
-        verify(eventRepository).getEvent(EVENT_ID, false);
-    }
-
-    @Test
-    public void shouldShowEventsIfNoneStored() {
-        mockCommons();
-
-        when(sharedPreferenceModel.getLong(anyString(), anyLong())).thenReturn(-1L);
-        ContextManager.setSelectedEvent(null);
-
-        mainPresenter.start();
-
-        verify(mainView).showEventList();
-    }
-
-    @Test
-    public void shouldShowResultInViewOnEventPush() {
-        mockCommons();
-
-        ContextManager.setSelectedEvent(null);
-        mainPresenter.start();
-        PUBLISHER.onNext(EVENT);
-
-        verify(mainView).showResult(EVENT);
     }
 
 }


### PR DESCRIPTION
Fixes #1122

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 
- Add EventViewModel extracting related code from MainPresenter
- Adds an ActionLiveData in order to send one time action from ViewModel to View.(Reference: Google MVVM samples)
- As a consequence, the dashboard no longer overrides the fragments.

Screenshots for the change: 
![videotogif_2018 06 22_21 10 43](https://user-images.githubusercontent.com/21277837/41785927-ad268c6a-7661-11e8-8513-1101222cd38b.gif)

**Note**
Tests will be added in a separate PR as this PR was getting huge. One more PR is needed in order to completely remove the MainPresenter. Tests will be added along with that PR.