### PR TITLE
chore: Set VmPolicy to penaltyLog

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/OrgaApplication.java
+++ b/app/src/main/java/org/fossasia/openevent/app/OrgaApplication.java
@@ -94,7 +94,7 @@ public class OrgaApplication extends MultiDexApplication implements HasActivityI
             StrictMode.setVmPolicy(
                 new StrictMode.VmPolicy.Builder()
                     .detectAll()
-                    .penaltyDeath()
+                    .penaltyLog()
                     .build());
 
             Timber.plant(new Timber.DebugTree());


### PR DESCRIPTION
Fixes #836 

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: Change VmPolicy to `penaltyLog`. ThreadPolicy isn't causing any issues right now hence left it untouched. Note that `penaltyDialog` is only available with ThreadPolicy.

Screenshots for the change: NA
