### PR TITLE
fix: Run onStart only once in EventViewModel

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/main/EventViewModel.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/main/EventViewModel.java
@@ -22,6 +22,7 @@ import static org.fossasia.openevent.app.core.main.MainActivity.EVENT_KEY;
 
 public class EventViewModel extends ViewModel {
     private final Preferences sharedPreferenceModel;
+    private boolean initialized = false;
     private final Bus bus;
     private final CurrencyUtils currencyUtils;
     private final EventRepository eventRepository;
@@ -43,6 +44,10 @@ public class EventViewModel extends ViewModel {
     }
 
     protected void onStart() {
+        if (initialized)
+            return;
+
+        initialized = true;
         compositeDisposable.add(bus.getSelectedEvent()
             .subscribe(event -> {
                 sharedPreferenceModel.setLong(EVENT_KEY, event.getId());


### PR DESCRIPTION
Fixes #589 

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: Run onStart only once in the EventViewModel and as a result stop dashboard from overriding the fragments.

Screenshots for the change: 
![videotogif_2018 07 02_10 04 00](https://user-images.githubusercontent.com/21277837/42145476-798142da-7ddf-11e8-975d-91f80a16199d.gif)


