### PR TITLE
fix: hide events list menu on fragment change

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/event/list/EventListFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/list/EventListFragment.java
@@ -10,6 +10,8 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
@@ -98,6 +100,8 @@ public class EventListFragment extends BaseFragment implements EventsView {
 
         binding.createEventFab.setOnClickListener(view -> openCreateEventFragment());
 
+        setHasOptionsMenu(true);
+
         return binding.getRoot();
     }
 
@@ -125,6 +129,12 @@ public class EventListFragment extends BaseFragment implements EventsView {
             refreshLayout.setRefreshing(false);
             eventsViewModel.loadUserEvents(true);
         });
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        super.onCreateOptionsMenu(menu, inflater);
+        inflater.inflate(R.menu.menu_events, menu);
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/openevent/app/core/event/list/pager/ListPageFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/event/list/pager/ListPageFragment.java
@@ -12,8 +12,6 @@ import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -82,7 +80,6 @@ public class ListPageFragment extends Fragment implements ListPageView, Injectab
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         context = getActivity();
-        setHasOptionsMenu(true);
     }
 
     @Override
@@ -94,11 +91,6 @@ public class ListPageFragment extends Fragment implements ListPageView, Injectab
         eventsViewModel = ViewModelProviders.of(getActivity(), viewModelFactory).get(EventsViewModel.class);
 
         return binding.getRoot();
-    }
-
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        super.onCreateOptionsMenu(menu, inflater);
-        inflater.inflate(R.menu.menu_events, menu);
     }
 
     @Override


### PR DESCRIPTION
Fixes #1198 

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: Correct place for instantiation of options menu, thus fixing persisting events list menu

Screenshots for the change:
![videotogif_2018 07 12_12 37 02](https://user-images.githubusercontent.com/35009811/42620828-b107ee78-85d9-11e8-915c-f238f1e2fa83.gif)

