### PR TITLE
fix: empty dashboard on back presses with no selected event

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/main/MainActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/main/MainActivity.java
@@ -105,6 +105,8 @@ public class MainActivity extends AppCompatActivity implements
             binding.drawerLayout.closeDrawer(GravityCompat.START);
         } else if (fragmentNavigator.isDashboardActive())
             super.onBackPressed();
+        else if (eventId == -1)
+            finish();
         else {
             fragmentNavigator.back();
             binding.navView.getMenu().findItem(R.id.nav_dashboard).setChecked(true);


### PR DESCRIPTION
Fixes #1203 

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: Handles back press when no event is selected.

Screenshots for the change:
<img src="https://user-images.githubusercontent.com/35009811/42734285-08e4bfa4-885f-11e8-90da-9001ccb625f2.gif" height="325"/>