### PR TITLE
feat: Confirm dialog on exiting Update Organizer Info

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/organizer/detail/OrganizerDetailActivity.java
+++ b/app/src/main/java/com/eventyay/organizer/core/organizer/detail/OrganizerDetailActivity.java
@@ -7,12 +7,15 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import com.eventyay.organizer.R;
+import com.eventyay.organizer.core.organizer.update.UpdateOrganizerInfoFragment;
 
 import javax.inject.Inject;
 
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.support.HasSupportFragmentInjector;
+
+import static com.eventyay.organizer.core.organizer.detail.OrganizerDetailFragment.INFO_FRAGMENT_TAG;
 
 public class OrganizerDetailActivity extends AppCompatActivity implements HasSupportFragmentInjector {
 
@@ -50,5 +53,15 @@ public class OrganizerDetailActivity extends AppCompatActivity implements HasSup
     @Override
     public AndroidInjector<Fragment> supportFragmentInjector() {
         return dispatchingAndroidInjector;
+    }
+
+    @Override
+    public void onBackPressed() {
+        UpdateOrganizerInfoFragment infoFragment = (UpdateOrganizerInfoFragment) fragmentManager.findFragmentByTag(INFO_FRAGMENT_TAG);
+        if (infoFragment != null) {
+            infoFragment.backPressed();
+        } else {
+            super.onBackPressed();
+        }
     }
 }

--- a/app/src/main/java/com/eventyay/organizer/core/organizer/detail/OrganizerDetailFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/organizer/detail/OrganizerDetailFragment.java
@@ -34,6 +34,7 @@ public class OrganizerDetailFragment extends BaseFragment<OrganizerDetailPresent
     ContextUtils utilModel;
     @Inject
     Lazy<OrganizerDetailPresenter> presenterProvider;
+    public static final String INFO_FRAGMENT_TAG = "info";
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -81,7 +82,7 @@ public class OrganizerDetailFragment extends BaseFragment<OrganizerDetailPresent
                 break;
             case R.id.update_organizer:
                 getFragmentManager().beginTransaction()
-                    .replace(R.id.fragment, UpdateOrganizerInfoFragment.newInstance())
+                    .replace(R.id.fragment, UpdateOrganizerInfoFragment.newInstance(), INFO_FRAGMENT_TAG)
                     .addToBackStack(null)
                     .commit();
                 break;

--- a/app/src/main/java/com/eventyay/organizer/core/organizer/update/UpdateOrganizerInfoFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/organizer/update/UpdateOrganizerInfoFragment.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.TextUtils;
@@ -41,6 +42,7 @@ public class UpdateOrganizerInfoFragment extends BaseFragment implements UpdateO
     private UpdateOrganizerLayoutBinding binding;
     private Validator validator;
     private UpdateOrganizerInfoViewModel updateOrganizerInfoViewModel;
+    private AlertDialog saveAlertDialog;
 
     public static UpdateOrganizerInfoFragment newInstance() {
         return new UpdateOrganizerInfoFragment();
@@ -151,4 +153,24 @@ public class UpdateOrganizerInfoFragment extends BaseFragment implements UpdateO
     public void onSuccess(String message) {
         Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
     }
+
+    @Override
+    public void backPressed() {
+        if (saveAlertDialog == null) {
+            saveAlertDialog = new AlertDialog.Builder(new ContextThemeWrapper(getContext(), R.style.AlertDialog))
+                .setMessage(getString(R.string.save_changes))
+                .setPositiveButton(getString(R.string.save), (dialog, which) -> {
+                    updateOrganizerInfoViewModel.updateOrganizer();
+                    dialog.dismiss();
+                    dismiss();
+                })
+                .setNegativeButton(getString(R.string.discard), (dialog, which) -> {
+                    dialog.dismiss();
+                    dismiss();
+                })
+                .create();
+        }
+        saveAlertDialog.show();
+    }
+
 }

--- a/app/src/main/java/com/eventyay/organizer/core/organizer/update/UpdateOrganizerInfoView.java
+++ b/app/src/main/java/com/eventyay/organizer/core/organizer/update/UpdateOrganizerInfoView.java
@@ -15,4 +15,6 @@ public interface UpdateOrganizerInfoView extends Progressive, Erroneous, Success
     void validate(TextInputLayout textInputLayout, Function<String, Boolean> function, String str);
 
     void setUser(User user);
+
+    void backPressed();
 }


### PR DESCRIPTION
Fixes #1334 

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: Adds confirmation when exiting UpdateOrganizerInfo Fragment

Screenshots for the change:
<img src="https://user-images.githubusercontent.com/35009811/44284026-c5539100-a27d-11e8-8fd8-8a06e0ef45e1.png" width="250" />