### PR TITLE
fix: Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ We realize that MVP is opinionated and there is no strict boundary between the r
 #### Project Structure
 
 Generally, projects are created using package by layer approach where packages are names by layers like `ui`, `activity`, `fragment`, etc but it quickly becomes unscalable in large projects where large number of unrelated classes are crammed in one layer and it becomes difficult to navigate through them.  
-Instead, we follow package by feature, which at the cost of flatness of our project, provides us packages of isolated functioning related classes which are likely to be a complete self sufficient component of the application. Each package all related classes of view, presenter, their implementations like Activities anf Fragments.  
+Instead, we follow package by feature, which at the cost of flatness of our project, provides us packages of isolated functioning related classes which are likely to be a complete self sufficient component of the application. Each package all related classes of view, presenter, their implementations like Activities and Fragments.  
 A notable exception to this is the `common` module and data classes like Models and Repositories as they are used in a cross component way.  
 ***Note:** The interface contract for Presenter and View is present in `contract` package in each module`*
 


### PR DESCRIPTION
Fixing the typing error in the Project Structure section.

Fixes #1370 

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ ] My branch is up-to-date with the Upstream development branch.

Changes: `anf` -> `and`