### PR TITLE
Issue App crashing on Opening in Android Oreo 8.1 #1356

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/OrgaApplication.java
+++ b/app/src/main/java/com/eventyay/organizer/OrgaApplication.java
@@ -89,6 +89,12 @@ public class OrgaApplication extends MultiDexApplication implements HasActivityI
             StrictMode.setThreadPolicy(
                 new StrictMode.ThreadPolicy.Builder()
                     .detectAll()
+                    /**
+                     * https://medium.com/@elye.project/walk-through-hell-with-android-strictmode-7e8605168032
+                     * "If you really like penaltyDeath(). Perhaps we could turn that permitDiskReads() by default.
+                     * Most of the detected violation from other sources that really need suppression are Disk Reading error."
+                     */
+                    .permitDiskReads()
                     .penaltyDeath()
                     .build());
             StrictMode.setVmPolicy(

--- a/app/src/main/java/com/eventyay/organizer/OrgaApplication.java
+++ b/app/src/main/java/com/eventyay/organizer/OrgaApplication.java
@@ -91,7 +91,7 @@ public class OrgaApplication extends MultiDexApplication implements HasActivityI
                 .detectAll()
                 .penaltyDeath();
 
-            if (android.os.Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 /**
                  * https://medium.com/@elye.project/walk-through-hell-with-android-strictmode-7e8605168032
                  * "If you really like penaltyDeath(). Perhaps we could turn that permitDiskReads() by default.

--- a/app/src/main/java/com/eventyay/organizer/OrgaApplication.java
+++ b/app/src/main/java/com/eventyay/organizer/OrgaApplication.java
@@ -2,6 +2,7 @@ package com.eventyay.organizer;
 
 import android.app.Activity;
 import android.content.Context;
+import android.os.Build;
 import android.os.StrictMode;
 import android.support.annotation.NonNull;
 import android.support.multidex.MultiDexApplication;
@@ -86,17 +87,20 @@ public class OrgaApplication extends MultiDexApplication implements HasActivityI
                     .enableWebKitInspector(Stetho.defaultInspectorModulesProvider(this))
                     .build());
 
-            StrictMode.setThreadPolicy(
-                new StrictMode.ThreadPolicy.Builder()
-                    .detectAll()
-                    /**
-                     * https://medium.com/@elye.project/walk-through-hell-with-android-strictmode-7e8605168032
-                     * "If you really like penaltyDeath(). Perhaps we could turn that permitDiskReads() by default.
-                     * Most of the detected violation from other sources that really need suppression are Disk Reading error."
-                     */
-                    .permitDiskReads()
-                    .penaltyDeath()
-                    .build());
+            StrictMode.ThreadPolicy.Builder policyBuilder = new StrictMode.ThreadPolicy.Builder()
+                .detectAll()
+                .penaltyDeath();
+
+            if (android.os.Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+                /**
+                 * https://medium.com/@elye.project/walk-through-hell-with-android-strictmode-7e8605168032
+                 * "If you really like penaltyDeath(). Perhaps we could turn that permitDiskReads() by default.
+                 * Most of the detected violation from other sources that really need suppression are Disk Reading error."
+                 */
+                policyBuilder
+                    .permitDiskReads();
+            }
+            StrictMode.setThreadPolicy(policyBuilder.build());
             StrictMode.setVmPolicy(
                 new StrictMode.VmPolicy.Builder()
                     .detectAll()


### PR DESCRIPTION
Fixes #1356 

After reading through some articles, I have found out that using strict policy on certain devices will cause a DiskReadViolation that may not be related to the app's code, but due to an external library or each hardware maker's specific software.

By outting " .permitDiskReads()" we can avert this situation. In the comment there is a link to an article where this is explained in detail.

Checklist:

- [X] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream development branch.

Changes: [Add here what changes were made in this issue and if possible provide links.]

Screenshots for the change:
