### PR TITLE
fix: Invalidate invalid field message on text changes

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/auth/signup/SignUpFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/auth/signup/SignUpFragment.java
@@ -68,24 +68,6 @@ public class SignUpFragment extends BaseFragment implements SignUpView {
         signUpViewModel.getSuccess().observe(this, this::onSuccess);
         signUpViewModel.getError().observe(this, this::showError);
 
-        /*binding.password.setOnFocusChangeListener(new View.OnFocusChangeListener() {
-            @Override
-            public void onFocusChange(View v, boolean hasFocus) {
-                if (!hasFocus) {
-                    validator.validate();
-                }
-            }
-        });
-
-        binding.confirmPassword.setOnFocusChangeListener(new View.OnFocusChangeListener() {
-            @Override
-            public void onFocusChange(View view, boolean hasFocus) {
-                if (!hasFocus) {
-                    validator.validate();
-                }
-            }
-        });*/
-
         binding.password.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {

--- a/app/src/main/java/com/eventyay/organizer/core/auth/signup/SignUpFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/auth/signup/SignUpFragment.java
@@ -68,7 +68,7 @@ public class SignUpFragment extends BaseFragment implements SignUpView {
         signUpViewModel.getSuccess().observe(this, this::onSuccess);
         signUpViewModel.getError().observe(this, this::showError);
 
-        binding.password.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+        /*binding.password.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
                 if (!hasFocus) {
@@ -83,6 +83,40 @@ public class SignUpFragment extends BaseFragment implements SignUpView {
                 if (!hasFocus) {
                     validator.validate();
                 }
+            }
+        });*/
+
+        binding.password.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                //do nothing
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+               //do nothing
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                    validator.validate();
+            }
+        });
+
+        binding.confirmPassword.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                //do nothing
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                //do nothing
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                    validator.validate();
             }
         });
 

--- a/app/src/main/java/com/eventyay/organizer/core/auth/signup/SignUpFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/auth/signup/SignUpFragment.java
@@ -68,6 +68,15 @@ public class SignUpFragment extends BaseFragment implements SignUpView {
         signUpViewModel.getSuccess().observe(this, this::onSuccess);
         signUpViewModel.getError().observe(this, this::showError);
 
+        binding.password.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                if (!hasFocus) {
+                    validator.validate();
+                }
+            }
+        });
+        
         binding.btnSignUp.setOnClickListener(view -> {
             if (!validator.validate())
                 return;

--- a/app/src/main/java/com/eventyay/organizer/core/auth/signup/SignUpFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/auth/signup/SignUpFragment.java
@@ -81,7 +81,7 @@ public class SignUpFragment extends BaseFragment implements SignUpView {
 
             @Override
             public void afterTextChanged(Editable s) {
-                    validator.validate();
+                validator.validate();
             }
         });
 
@@ -98,7 +98,7 @@ public class SignUpFragment extends BaseFragment implements SignUpView {
 
             @Override
             public void afterTextChanged(Editable s) {
-                    validator.validate();
+                validator.validate();
             }
         });
 

--- a/app/src/main/java/com/eventyay/organizer/core/auth/signup/SignUpFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/auth/signup/SignUpFragment.java
@@ -76,7 +76,16 @@ public class SignUpFragment extends BaseFragment implements SignUpView {
                 }
             }
         });
-        
+
+        binding.confirmPassword.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View view, boolean hasFocus) {
+                if (!hasFocus) {
+                    validator.validate();
+                }
+            }
+        });
+
         binding.btnSignUp.setOnClickListener(view -> {
             if (!validator.validate())
                 return;


### PR DESCRIPTION
Fixes #1391 

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 

Now the invalid field message will disappear when the user corrects the length of the password and then clicks on some other field.

Screenshots:

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/35566748/48199821-4d2fcf80-e383-11e8-9a17-59bec7fa96dc.gif)
