### PR TITLE
fix: Confirm password filling automatically on device rotation

### DIFF
--- a/app/src/main/res/layout/sign_up_fragment.xml
+++ b/app/src/main/res/layout/sign_up_fragment.xml
@@ -99,7 +99,6 @@
                         android:layout_height="wrap_content"
                         android:id="@+id/confirmPassword"
                         android:hint="@string/confirm_password"
-                        android:text="@={ user.password }"
                         android:inputType="textPassword"
                         android:imeOptions="actionGo"
                         app:validateMinLength="@{6}"


### PR DESCRIPTION
Fixes #1374 

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream development branch.

Changes: Removed the user.password field from confirm password edit text, which populated the confirm password edit text when the device screen was rotated. 
Explanation : When the user entered the password, the password was stored in an object of the User class. When the screen was rotated, the confirm password edit text referred the same field, which caused that field to get filled with the same password that was entered by the user in the password field. 

Screenshots for the change:

Previous behaviour:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/31106411/50629562-13361080-0f63-11e9-9d94-d93da68490d3.gif)

Current behaviour:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/31106411/50629729-d585b780-0f63-11e9-9e29-fd759564caac.gif)



