### PR TITLE
fix: Move Share button to the right and add 'Not now' button

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/event/dashboard/EventDashboardFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/dashboard/EventDashboardFragment.java
@@ -42,6 +42,7 @@ public class EventDashboardFragment extends BaseFragment<EventDashboardPresenter
     private long initialEventId;
     private EventDetailBinding binding;
     private AlertDialog unpublishDialog;
+    private AlertDialog shareEventDialog;
 
     @Inject
     Context context;
@@ -218,8 +219,20 @@ public class EventDashboardFragment extends BaseFragment<EventDashboardPresenter
     }
 
     public void showEventShareDialog() {
-        ViewUtils.showDialog(this, getString(R.string.share_event),
-            getString(R.string.successfull_publish_message), getString(R.string.share), this::shareEvent);
+       if (shareEventDialog == null) {
+            shareEventDialog = new AlertDialog.Builder(new ContextThemeWrapper(getActivity(), R.style.AlertDialog))
+                .setTitle(R.string.share_event)
+                .setMessage(getString(R.string.successfull_publish_message))
+                .setPositiveButton(R.string.share, (dialog, which) -> {
+                    shareEvent();
+                })
+                .setNegativeButton(R.string.not_now, (dialog, which) -> {
+                    dialog.dismiss();
+                })
+                .create();
+        }
+
+        shareEventDialog.show();
     }
 
     public void switchEventState() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -343,6 +343,7 @@
     <string name="successfull_publish_message">Congrats! Your event is live. Spread the word about your event.</string>
     <string name="unpublish_event">Unpublish Event</string>
     <string name="share_event">Share Event</string>
+    <string name="not_now">Not now</string>
     <string name="event_location_required">Please add event location to publish the event</string>
     <string name="add_location">Add Location</string>
     <string name="event_location">Event Location</string>


### PR DESCRIPTION
Fixes #1419 

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 

Now the share button appears on the right side in the dialog box and a not now button has been added which closes the dialog.

Screenshots for the change:

![screenshot_2019-01-05-17-42-18-832_com eventyay organizer](https://user-images.githubusercontent.com/35566748/50724311-6948b680-1111-11e9-8511-e1b59a2914c8.png)