### PR TITLE
fix: focus on sponsor name and show keyboard when create spononsor fragment is opened

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/sponsor/create/CreateSponsorFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/sponsor/create/CreateSponsorFragment.java
@@ -54,6 +54,8 @@ public class CreateSponsorFragment extends BaseFragment implements CreateSponsor
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         binding =  DataBindingUtil.inflate(inflater, R.layout.sponsor_create_layout, container, false);
+        binding.form.name.requestFocus();
+        ViewUtils.showKeyboard(getContext());
         createSponsorViewModel = ViewModelProviders.of(this, viewModelFactory).get(CreateSponsorViewModel.class);
         validator = new Validator(binding.form);
 

--- a/app/src/main/java/com/eventyay/organizer/ui/ViewUtils.java
+++ b/app/src/main/java/com/eventyay/organizer/ui/ViewUtils.java
@@ -61,6 +61,11 @@ public final class ViewUtils {
         });
     }
 
+    public static void showKeyboard(Context context) {
+        InputMethodManager manager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+        manager.toggleSoftInput(InputMethodManager.SHOW_FORCED, InputMethodManager.HIDE_IMPLICIT_ONLY);
+    }
+
     public static void hideKeyboard(View view) {
         if (view != null) {
             InputMethodManager manager = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);


### PR DESCRIPTION
Fixes #1430 

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: Sponsor Name field will have focus and keyboard will open when Create Sponsor fragment is opened.
![gif-190111_013312](https://user-images.githubusercontent.com/32304546/50994449-4881c600-1542-11e9-91b1-98e53d74fc66.gif)



GIF for the change:
