### PR TITLE
fix: Validate Create Track fields for just spaces without any text

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/track/create/CreateTrackFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/track/create/CreateTrackFragment.java
@@ -40,6 +40,11 @@ public class CreateTrackFragment extends BaseFragment<CreateTrackPresenter> impl
         validator = new Validator(binding.form);
 
         binding.submit.setOnClickListener(view -> {
+
+            binding.form.trackName.setText(binding.form.trackName.getText().toString().trim());
+            binding.form.trackDescription.setText(binding.form.trackDescription.getText().toString().trim());
+            binding.form.trackColor.setText(binding.form.trackColor.getText().toString().trim());
+
             if (validator.validate())
                 getPresenter().createTrack();
 

--- a/app/src/main/java/com/eventyay/organizer/core/track/update/UpdateTrackFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/track/update/UpdateTrackFragment.java
@@ -52,6 +52,11 @@ public class UpdateTrackFragment extends BaseBottomSheetFragment<UpdateTrackPres
         trackId = bundle.getLong(TRACK_ID);
 
         binding.submit.setOnClickListener(view -> {
+
+            binding.form.trackName.setText(binding.form.trackName.getText().toString().trim());
+            binding.form.trackDescription.setText(binding.form.trackDescription.getText().toString().trim());
+            binding.form.trackColor.setText(binding.form.trackColor.getText().toString().trim());
+
             if (validator.validate())
                 getPresenter().updateTrack();
         });


### PR DESCRIPTION
Fixes #1434 

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes:

Now, submission of details will display error if user enters just spaces without any text in the Name and Color fields.