### PR TITLE
fix:App returns from Settings to main activity on back pressed

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/main/FragmentNavigator.java
+++ b/app/src/main/java/com/eventyay/organizer/core/main/FragmentNavigator.java
@@ -3,6 +3,7 @@ package com.eventyay.organizer.core.main;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
+import android.util.Log;
 
 import com.eventyay.organizer.R;
 import com.eventyay.organizer.core.attendee.list.AttendeesFragment;
@@ -27,6 +28,7 @@ class FragmentNavigator {
     private long eventId;
 
     private boolean dashboardActive = true;
+    private boolean deviceSettingsActive = false;
     private int lastSelectedNavItemId;
 
     FragmentNavigator(FragmentManager fragmentManager, long eventId) {
@@ -36,6 +38,10 @@ class FragmentNavigator {
 
     public boolean isDashboardActive() {
         return dashboardActive;
+    }
+
+    public boolean isDeviceSettingsActive(){
+        return deviceSettingsActive;
     }
 
     public long getEventId() {
@@ -119,6 +125,8 @@ class FragmentNavigator {
 
         FragmentTransaction transaction = fragmentManager.beginTransaction();
         dashboardActive = navItemId == R.id.nav_dashboard;
+        deviceSettingsActive = navItemId == R.id.nav_settings;
+        Log.d("DASHBOARD",navItemId+"");
         if (dashboardActive) {
             transaction.replace(R.id.fragment_container, fragment);
         } else {

--- a/app/src/main/java/com/eventyay/organizer/core/main/MainActivity.java
+++ b/app/src/main/java/com/eventyay/organizer/core/main/MainActivity.java
@@ -24,6 +24,7 @@ import com.eventyay.organizer.data.user.User;
 import com.eventyay.organizer.databinding.MainActivityBinding;
 import com.eventyay.organizer.databinding.MainNavHeaderBinding;
 import com.eventyay.organizer.ui.ViewUtils;
+import com.squareup.haha.perflib.Main;
 
 import java.util.Arrays;
 import java.util.List;
@@ -113,6 +114,10 @@ public class MainActivity extends AppCompatActivity implements
             super.onBackPressed();
         else if (eventId == -1)
             finish();
+        else if (fragmentNavigator.isDeviceSettingsActive()){
+            startActivity(new Intent(getApplicationContext(), MainActivity.class));
+            finish();
+        }
         else {
             int lastSelectedNavItemId = fragmentNavigator.back();
             binding.navView.getMenu().findItem(lastSelectedNavItemId).setChecked(true);


### PR DESCRIPTION
Fix: #1377  App should return back to the Main Activity from the Device Settings activity

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: checked in the onBackPressed() method if the deviceSetting is visible or not, if it is there started the Main Activity
