### PR TITLE
Fixed #1441  Edit event triggers to upload image from anywhere in the layout of edit event

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/event/create/UpdateEventFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/UpdateEventFragment.java
@@ -109,7 +109,7 @@ public class UpdateEventFragment extends BaseFragment implements CreateEventView
 
         setHasOptionsMenu(true);
 
-        binding.form.eventOriginalImageLayout.setOnClickListener(view -> {
+        binding.form.eventOriginalImage.setOnClickListener(view -> {
             Intent intent = new Intent();
             intent.setType("image/*");
             intent.setAction(Intent.ACTION_GET_CONTENT);


### PR DESCRIPTION
Fixes #1441  

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 

Upload Image option now gets trigger when we tap on the imageview of Update event and not from anywhere else in the layout.