### PR TITLE
fix: Prevent Scan QR FAB from showing on empty attendees list

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/attendee/list/AttendeesFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/attendee/list/AttendeesFragment.java
@@ -254,7 +254,7 @@ public class AttendeesFragment extends BaseFragment<AttendeesPresenter> implemen
 
             @Override
             public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
-                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                if ((newState == RecyclerView.SCROLL_STATE_IDLE) && recyclerView.getAdapter().getItemCount() != 0) {
                     binding.fabScanQr.show();
                 }
                 super.onScrollStateChanged(recyclerView, newState);

--- a/app/src/main/java/com/eventyay/organizer/core/attendee/list/AttendeesFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/attendee/list/AttendeesFragment.java
@@ -254,7 +254,7 @@ public class AttendeesFragment extends BaseFragment<AttendeesPresenter> implemen
 
             @Override
             public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
-                if ((newState == RecyclerView.SCROLL_STATE_IDLE) && recyclerView.getAdapter().getItemCount() != 0) {
+                if (newState == RecyclerView.SCROLL_STATE_IDLE && recyclerView.getAdapter().getItemCount() != 0) {
                     binding.fabScanQr.show();
                 }
                 super.onScrollStateChanged(recyclerView, newState);


### PR DESCRIPTION
Fixes #1465 

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 

Now, the FAB would not appear on scrolling if the list of attendees is empty.