### PR TITLE
fix: Validate Create FAQ question and answer fields for just spaces without text

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/faq/create/CreateFaqFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/faq/create/CreateFaqFragment.java
@@ -44,6 +44,9 @@ public class CreateFaqFragment extends BaseFragment implements CreateFaqView {
         validator = new Validator(binding.form);
 
         binding.submit.setOnClickListener(view -> {
+            binding.form.faqQuestion.setText(binding.form.faqQuestion.getText().toString().trim());
+            binding.form.faqAnswer.setText(binding.form.faqAnswer.getText().toString().trim());
+
             if (validator.validate())
                 createFaqViewModel.createFaq();
 


### PR DESCRIPTION
Fixes #1468 

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 

After this change, submission will display error if user enters just spaces without any text in the question and answer fields of Create FAQ.