### PR TITLE
fix: Add null check before sorting events

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/event/list/EventsViewModel.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/list/EventsViewModel.java
@@ -44,20 +44,26 @@ public class EventsViewModel extends ViewModel {
 
     public LiveData<List<Event>> getEvents(int position) {
         switch (position) {
-            case 0: return liveEvents;
-            case 1: return pastEvents;
-            case 2: return draftEvents;
-            default: return events;
+            case 0:
+                return liveEvents;
+            case 1:
+                return pastEvents;
+            case 2:
+                return draftEvents;
+            default:
+                return events;
         }
     }
 
     public void sortBy(int criteria) {
-        if (criteria == SORTBYNAME)
-            Collections.sort(events.getValue(), (e1, e2) -> e1.getName().compareToIgnoreCase(e2.getName()));
-        else {
-            Collections.sort(events.getValue(), DateService::compareEventDates);
+        if (events.getValue() != null) {
+            if (criteria == SORTBYNAME)
+                Collections.sort(events.getValue(), (e1, e2) -> e1.getName().compareToIgnoreCase(e2.getName()));
+            else {
+                Collections.sort(events.getValue(), DateService::compareEventDates);
+            }
+            filter();
         }
-        filter();
     }
 
     public void loadUserEvents(boolean forceReload) {

--- a/app/src/main/java/com/eventyay/organizer/core/event/list/EventsViewModel.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/list/EventsViewModel.java
@@ -56,14 +56,15 @@ public class EventsViewModel extends ViewModel {
     }
 
     public void sortBy(int criteria) {
-        if (events.getValue() != null) {
-            if (criteria == SORTBYNAME)
-                Collections.sort(events.getValue(), (e1, e2) -> e1.getName().compareToIgnoreCase(e2.getName()));
-            else {
-                Collections.sort(events.getValue(), DateService::compareEventDates);
-            }
-            filter();
+        if (events.getValue() == null) {
+            return;
         }
+        if (criteria == SORTBYNAME)
+            Collections.sort(events.getValue(), (e1, e2) -> e1.getName().compareToIgnoreCase(e2.getName()));
+        else {
+            Collections.sort(events.getValue(), DateService::compareEventDates);
+        }
+        filter();
     }
 
     public void loadUserEvents(boolean forceReload) {


### PR DESCRIPTION
Fixes #1493 App crashes on sorting events list when list is empty 

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 
Added a null check in sortBy function
