### PR TITLE
fix: Check correct event state radio button in Edit Event

### DIFF
--- a/app/src/main/res/layout/event_create_form.xml
+++ b/app/src/main/res/layout/event_create_form.xml
@@ -827,6 +827,7 @@
                         android:id="@+id/draft_state"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:checked='@{ event.getState.equals("draft") ? true : false }'
                         android:onCheckedChanged='@{ (switch, checked) -> (checked == true) ? event.setState("draft") : event.setState("published") }'
                         android:text="@string/draft" />
 
@@ -834,7 +835,6 @@
                         android:id="@+id/published_state"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:checked="true"
                         android:text="@string/published" />
 
                 </RadioGroup>


### PR DESCRIPTION
Fixes #1510 

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 

Now, the correct state radio button would remain checked in Edit Event.

GIF for the change:

![ezgif com-video-to-gif 45](https://user-images.githubusercontent.com/35566748/52494207-6569f180-2bf3-11e9-8724-1e150f48ccb9.gif)