### PR TITLE
fix: Make Google Plus field accessible in update organizer form

### DIFF
--- a/app/src/main/res/layout/update_organizer_form.xml
+++ b/app/src/main/res/layout/update_organizer_form.xml
@@ -320,7 +320,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:layout_marginBottom="@dimen/spacing_extra_large">
 
             <ImageView
                 android:layout_width="wrap_content"


### PR DESCRIPTION
Fixes #1525 

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 

Provided bottom margin for the Google Plus field so that it does not hide behind the 'Done' button.

Screenshots for the change:

![screenshot_2019-03-05-17-18-43-898_com eventyay organizer](https://user-images.githubusercontent.com/35566748/53803648-56186280-3f6b-11e9-900b-37c8cfb0943a.png)