### PR TITLE
fix: DatePicker and TimePicker doesn't display time chosen before when clicked

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/ui/views/AbstractDateTimePicker.java
+++ b/app/src/main/java/com/eventyay/organizer/ui/views/AbstractDateTimePicker.java
@@ -16,6 +16,7 @@ import timber.log.Timber;
 public abstract class AbstractDateTimePicker extends androidx.appcompat.widget.AppCompatButton {
     private final ObservableString value = new ObservableString();
     private OnDateTimeChangedListener onDateChangedListener;
+    private LocalDateTime current;
 
     public AbstractDateTimePicker(Context context) {
         super(context);
@@ -33,7 +34,7 @@ public abstract class AbstractDateTimePicker extends androidx.appcompat.widget.A
     }
 
     private void init() {
-        LocalDateTime current = LocalDateTime.now();
+        current = LocalDateTime.now();
         String isoDate = DateUtils.formatDateToIso(current);
         setValue(isoDate);
     }
@@ -45,16 +46,9 @@ public abstract class AbstractDateTimePicker extends androidx.appcompat.widget.A
 
         this.setText(DateUtils.formatDateWithDefault(format, date));
 
-        this.setOnClickListener(view -> {
-            ZonedDateTime zonedDateTime;
-            try {
-                zonedDateTime = DateUtils.getDate(date);
-            } catch (DateTimeParseException pe) {
-                Timber.e(pe);
-                zonedDateTime  = ZonedDateTime.now();
-            }
-            dialogProvider.apply(zonedDateTime).show();
-        });
+        this.setOnClickListener(view ->
+            dialogProvider.apply(DateUtils.getDate(DateUtils.formatDateToIso(current))).show()
+        );
     }
 
     public void setOnDateChangedListener(OnDateTimeChangedListener onDateChangedListener) {
@@ -62,6 +56,7 @@ public abstract class AbstractDateTimePicker extends androidx.appcompat.widget.A
     }
 
     public void setPickedDate(LocalDateTime pickedDate, String format) {
+        current = pickedDate;
         String isoDate = DateUtils.formatDateToIso(pickedDate);
         this.value.set(isoDate);
         String formattedDate = DateUtils.formatDateWithDefault(format, isoDate);


### PR DESCRIPTION
Fix: DatePicker and TimePicker doesn't display time chosen before when clicked

Fixes #1548 

Changes: 
I change the use of ZonedDateTime by the currentTime chosen before so that whenever we click on TimePicker or DatePicker, it shows the current time and date chosen

Screenshots for the change:
<img src="https://i.ibb.co/5Ksg3T5/ezgif-1-60c90ea37e73.gif" width="300">