### PR TITLE
fix: Show wrong start time error after first step itself

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/event/create/CreateEventViewModel.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/CreateEventViewModel.java
@@ -5,7 +5,6 @@ import android.arch.lifecycle.MutableLiveData;
 import android.arch.lifecycle.ViewModel;
 
 import com.eventyay.organizer.common.Constants;
-import com.eventyay.organizer.common.livedata.SingleEventLiveData;
 import com.eventyay.organizer.common.rx.Logger;
 import com.eventyay.organizer.data.Preferences;
 import com.eventyay.organizer.data.event.Event;
@@ -121,6 +120,11 @@ public class CreateEventViewModel extends ViewModel {
 
             if (!end.isAfter(start)) {
                 onError.setValue("End time should be after start time");
+                return false;
+            }
+
+            if (start.isBefore(ZonedDateTime.now())) {
+                onError.setValue("Start time should be after the current time");
                 return false;
             }
             return true;


### PR DESCRIPTION
Fixes #1584 

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ ] My branch is up-to-date with the Upstream development branch.

Changes: 

Added verification for the case when start time is before current time which would be verified during the first step of event creation along with proper error message.

Also removed an unused import.