### PR TITLE
fix: Create SpeakerStatistics

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/data/event/EventStatistics.java
+++ b/app/src/main/java/com/eventyay/organizer/data/event/EventStatistics.java
@@ -22,7 +22,7 @@ public class EventStatistics {
     public String id;
 
     public Long sessions;
-    public Long speakers;
+    public SpeakerStatistics speakers;
     public Long sessionsPending;
     public Long sponsors;
     public Long sessionsSubmitted;

--- a/app/src/main/java/com/eventyay/organizer/data/event/SpeakerStatistics.java
+++ b/app/src/main/java/com/eventyay/organizer/data/event/SpeakerStatistics.java
@@ -1,0 +1,32 @@
+package com.eventyay.organizer.data.event;
+
+
+import com.github.jasminb.jsonapi.LongIdHandler;
+import com.github.jasminb.jsonapi.annotations.Id;
+import com.github.jasminb.jsonapi.annotations.Type;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
+
+import com.eventyay.organizer.data.db.configuration.OrgaDatabase;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@Type("speakerStatistics")
+@NoArgsConstructor
+@ToString()
+@Table(database = OrgaDatabase.class, allFields = true)
+public class SpeakerStatistics {
+
+    @Id(LongIdHandler.class)
+    @PrimaryKey
+    public Long id;
+
+    public Long accepted;
+    public Long confirmed;
+    public Long pending;
+    public Long rejected;
+    public Long total;
+}

--- a/app/src/main/res/layout/event_statistics.xml
+++ b/app/src/main/res/layout/event_statistics.xml
@@ -180,7 +180,7 @@
                         android:layout_marginBottom="@dimen/spacing_normal"
                         android:layout_marginLeft="@dimen/spacing_large"
                         android:layout_marginStart="@dimen/spacing_large"
-                        android:text="@{ BindingAdapters.longToStr(eventStatistics.speakers) }"
+                        android:text="@{ BindingAdapters.longToStr(eventStatistics.speakers.accepted) }"
                         android:textSize="@dimen/text_size_normal" />
 
                     <TextView


### PR DESCRIPTION
**Fixes** #1586 

**Checklist**

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

**Changes**

Creates another class for speaker statistics to incorporate the sub-fields of the speakers object.
Hence fixes the `JsonMappingException: Can not deserialize instance of java.lang.Long out of START_OBJECT token` on loading the event dashboard.
