### PR TITLE
fix: Prevent closing of Edit Event without confirmation dialog

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/event/create/CreateEventActivity.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/CreateEventActivity.java
@@ -150,6 +150,7 @@ public class CreateEventActivity extends AppCompatActivity implements HasSupport
                 })
                 .create();
             saveAlertDialog.show();
+            saveAlertDialog = null;
         } else {
             super.onBackPressed();
         }


### PR DESCRIPTION
Fixes #1638 

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ ] My branch is up-to-date with the Upstream development branch.

Changes: 

Now, alert dialog would appear whenever the dialog is not there on the screen and the back button is pressed.

GIF:

![ezgif com-video-to-gif (72)](https://user-images.githubusercontent.com/35566748/57573688-40328c80-7449-11e9-9e3f-b7730b94c33e.gif)