### PR TITLE
chore: Bump version code and name for release of v1.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,8 +24,8 @@ android {
         applicationId "com.eventyay.organizer"
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
-        versionCode 9
-        versionName "1.1.1"
+        versionCode 10
+        versionName "1.2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         manifestPlaceholders = [


### PR DESCRIPTION
Updated version code to `10` and version name to `1.2.0`.