### PR TITLE
fix: Retain state of statistics switches on screen rotation

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/event/dashboard/EventDashboardFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/dashboard/EventDashboardFragment.java
@@ -104,8 +104,6 @@ public class EventDashboardFragment extends BaseFragment<EventDashboardPresenter
     public void onStart() {
         super.onStart();
         getPresenter().attach(initialEventId, this);
-        binding.eventStatistics.switchEventStatistics.setChecked(false);
-        binding.orderStatistics.switchOrderStatistics.setChecked(false);
         binding.setPresenter(getPresenter());
         setupRefreshListener();
         getPresenter().start();

--- a/app/src/main/res/layout/event_statistics.xml
+++ b/app/src/main/res/layout/event_statistics.xml
@@ -54,7 +54,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:visibility="gone"
+            android:visibility="@{ switchEventStatistics.checked ? View.VISIBLE : View.GONE }"
             android:weightSum="200">
 
             <LinearLayout

--- a/app/src/main/res/layout/order_statistics.xml
+++ b/app/src/main/res/layout/order_statistics.xml
@@ -56,7 +56,7 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:weightSum="200"
-            android:visibility="gone">
+            android:visibility="@{ switchOrderStatistics.checked ? View.VISIBLE : View.GONE }">
 
             <LinearLayout
                 android:id="@+id/order_statistics_layout"


### PR DESCRIPTION
Fixes #1574  

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 

State of Event Statistics switch and Order Statistics switch would now be retained on screen rotation.

GIF for the change:

![ezgif com-video-to-gif (88)](https://user-images.githubusercontent.com/35566748/59875681-04330580-93bf-11e9-9dbc-a29bc414ed6f.gif)