### PR TITLE
chore: Move 'My Events' to the first position in navigation drawer

### DIFF
--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <group android:id="@+id/eventsMenu" android:checkableBehavior="single">
+        <item
+            android:id="@+id/nav_events"
+            android:icon="@drawable/ic_events"
+            android:title="@string/nav_events" />
+    </group>
+
     <group android:id="@+id/subMenu" android:checkableBehavior="single">
         <item
             android:id="@+id/nav_dashboard"
@@ -85,13 +92,6 @@
             android:title="@string/event_settings"
             android:checkable="true"/>
 
-    </group>
-
-    <group android:id="@+id/eventsMenu" android:checkableBehavior="single">
-        <item
-            android:id="@+id/nav_events"
-            android:icon="@drawable/ic_events"
-            android:title="@string/nav_events" />
     </group>
 
     <group android:id="@+id/mainMenu">


### PR DESCRIPTION
Fixes #1748 

Changes: 

Shifted 'My Events' to the first position in navigation drawer.

Screenshot for the change:

![My Events to top](https://user-images.githubusercontent.com/35566748/60020733-40f84880-96ae-11e9-9b8c-6a47770f6cef.jpeg)